### PR TITLE
comprehensive terminal UI overhaul

### DIFF
--- a/app/blog/hello-world/layout.tsx
+++ b/app/blog/hello-world/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import Link from "next/link";
+
+export default function PostLayout({ children }: { children: ReactNode }) {
+  return (
+    <article>
+      <nav aria-label="Breadcrumb">
+        <Link href="/blog" className="terminal-muted" style={{ fontSize: "0.85rem" }}>
+          &larr; back to /blog
+        </Link>
+      </nav>
+      {children}
+    </article>
+  );
+}

--- a/app/blog/hello-world/page.mdx
+++ b/app/blog/hello-world/page.mdx
@@ -1,5 +1,14 @@
+export const meta = {
+  title: "Hello World",
+  date: "2025-12-04",
+  description: "My first blog post using MDX in Next.js.",
+}
+
 <section className="terminal-hero">
-    <h1 className="terminal-title">/blog/hello-word</h1>
+  <h1 className="terminal-title">{meta.title}</h1>
+  <time className="terminal-muted" dateTime={meta.date}>
+    {new Date(meta.date + "T00:00:00").toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })}
+  </time>
 </section>
 
 Welcome to my first blog post!

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from "react";
+
+export default function BlogLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,19 +1,42 @@
+import type { Metadata } from "next";
 import Link from 'next/link';
+import { posts } from './posts';
+
+export const metadata: Metadata = {
+  title: "Blog",
+  description: "Thoughts, notes, and the occasional tutorial.",
+  openGraph: {
+    title: "Blog | Atqa Munzir",
+    description: "Thoughts, notes, and the occasional tutorial.",
+  },
+};
 
 export default function BlogIndex() {
   return (
-    <div className="space-y-6">
+    <div>
       <section className="terminal-hero">
         <h1 className="terminal-title">/blog</h1>
       </section>
 
-      <article>
-        <Link href="/blog/hello-world" className="terminal-card">
-          <h2 className="terminal-card-title">Hello World</h2>
-          <p className="terminal-muted text-sm">December 4, 2025</p>
-          <p className="terminal-card-desc">This is my first blog post using MDX in Next.js...</p>
-        </Link>
-      </article>
+      <div className="terminal-blog-list">
+        {posts.map((post) => (
+          <article key={post.slug}>
+            <Link href={`/blog/${post.slug}`} className="terminal-card">
+              <div className="terminal-card-header">
+                <time dateTime={post.date} className="terminal-card-status">
+                  {new Date(post.date + "T00:00:00").toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </time>
+              </div>
+              <h2 className="terminal-card-title">{post.title}</h2>
+              <p className="terminal-card-desc">{post.description}</p>
+            </Link>
+          </article>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/blog/posts.ts
+++ b/app/blog/posts.ts
@@ -1,0 +1,15 @@
+export interface PostMeta {
+  slug: string;
+  title: string;
+  date: string;
+  description: string;
+}
+
+export const posts: PostMeta[] = [
+  {
+    slug: "hello-world",
+    title: "Hello World",
+    date: "2025-12-04",
+    description: "My first blog post using MDX in Next.js.",
+  },
+].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());

--- a/app/components/site-shell.tsx
+++ b/app/components/site-shell.tsx
@@ -25,21 +25,6 @@ export function SiteShell({ children }: SiteShellProps) {
 
   return (
     <div className="site-frame">
-      <div className="site-titlebar">
-        <div className="site-window-dots" aria-hidden="true">
-          <span className="site-dot site-dot--close" />
-          <span className="site-dot site-dot--minimize" />
-          <span className="site-dot site-dot--maximize" />
-        </div>
-        <span className="site-titlebar-path">
-          atqamz@web:~{pathname === "/" ? "" : pathname}
-        </span>
-        <div className="site-titlebar-controls">
-          <PaletteSelect />
-          <ThemeToggle />
-        </div>
-      </div>
-
       <header className="site-header">
         <Link href="/" className="site-logo" aria-label="Home">
           atqamz
@@ -60,6 +45,10 @@ export function SiteShell({ children }: SiteShellProps) {
             );
           })}
         </nav>
+        <div className="site-header-controls">
+          <PaletteSelect />
+          <ThemeToggle />
+        </div>
       </header>
 
       <a href="#main-content" className="skip-link">

--- a/app/components/site-shell.tsx
+++ b/app/components/site-shell.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from "react";
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { PaletteSelect } from "./palette-select";
 import { ThemeToggle } from "./theme-toggle";
 
@@ -9,32 +10,74 @@ type SiteShellProps = {
   children: ReactNode;
 };
 
+const NAV_LINKS = [
+  { href: "/blog", label: "/blog" },
+  { href: "/resume", label: "/resume" },
+];
+
+function isActive(pathname: string, href: string) {
+  if (href === "/") return pathname === "/";
+  return pathname === href || pathname.startsWith(href + "/");
+}
+
 export function SiteShell({ children }: SiteShellProps) {
+  const pathname = usePathname();
+
   return (
     <div className="site-frame">
+      <div className="site-titlebar">
+        <div className="site-window-dots" aria-hidden="true">
+          <span className="site-dot site-dot--close" />
+          <span className="site-dot site-dot--minimize" />
+          <span className="site-dot site-dot--maximize" />
+        </div>
+        <span className="site-titlebar-path">
+          atqamz@web:~{pathname === "/" ? "" : pathname}
+        </span>
+        <div className="site-titlebar-controls">
+          <PaletteSelect />
+          <ThemeToggle />
+        </div>
+      </div>
+
       <header className="site-header">
-        <nav className="site-nav">
-          <div className="site-nav-left">
-            <Link href="/" className="site-logo">atqamz</Link>
-            <Link href="/blog" className="site-link">/blog</Link>
-            <Link href="/resume" className="site-link">/resume</Link>
-          </div>
-          <div className="site-divider" aria-hidden="true" />
-          <div className="site-actions">
-            <PaletteSelect />
-            <ThemeToggle />
-          </div>
+        <Link href="/" className="site-logo" aria-label="Home">
+          atqamz
+        </Link>
+        <nav className="site-nav" aria-label="Main navigation">
+          {NAV_LINKS.map((link) => {
+            const active = isActive(pathname, link.href);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`site-link${active ? " site-link--active" : ""}`}
+                aria-current={active ? "page" : undefined}
+              >
+                {active && <span className="site-link-indicator" aria-hidden="true">&gt;</span>}
+                {link.label}
+              </Link>
+            );
+          })}
         </nav>
       </header>
-      <main className="site-main">
+
+      <a href="#main-content" className="skip-link">
+        Skip to content
+      </a>
+
+      <main id="main-content" className="site-main">
         {children}
       </main>
-      <footer className="site-footer">
-        <div className="site-footer-links">
-          <a href="https://github.com/atqamz" target="_blank" rel="noopener noreferrer">GitHub</a>
-          <a href="https://www.linkedin.com/in/atqamunzir/" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+
+      <footer className="site-statusbar">
+        <div className="site-statusbar-left">
+          <a href="https://github.com/atqamz" target="_blank" rel="noopener noreferrer">github</a>
+          <a href="https://www.linkedin.com/in/atqamunzir/" target="_blank" rel="noopener noreferrer">linkedin</a>
         </div>
-        <p className="terminal-muted">© {new Date().getFullYear()} Atqa Munzir.</p>
+        <span className="site-statusbar-right">
+          &copy; {new Date().getFullYear()} atqa munzir
+        </span>
       </footer>
     </div>
   );

--- a/app/components/terminal-favicon.tsx
+++ b/app/components/terminal-favicon.tsx
@@ -37,6 +37,7 @@ export function TerminalFavicon() {
       return { accent, background };
     };
 
+    const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
     let blinkOn = true;
     const link = ensureLink();
 
@@ -49,10 +50,26 @@ export function TerminalFavicon() {
 
     updateIcon();
 
-    const interval = window.setInterval(() => {
-      blinkOn = !blinkOn;
-      updateIcon();
-    }, BLINK_INTERVAL);
+    let interval: number | null = null;
+
+    const startBlink = () => {
+      if (prefersReducedMotion.matches) {
+        if (interval) {
+          window.clearInterval(interval);
+          interval = null;
+        }
+        blinkOn = true;
+        updateIcon();
+        return;
+      }
+      interval = window.setInterval(() => {
+        blinkOn = !blinkOn;
+        updateIcon();
+      }, BLINK_INTERVAL);
+    };
+
+    startBlink();
+    prefersReducedMotion.addEventListener("change", startBlink);
 
     const observer = new MutationObserver(() => updateIcon());
     observer.observe(document.documentElement, {
@@ -61,7 +78,8 @@ export function TerminalFavicon() {
     });
 
     return () => {
-      window.clearInterval(interval);
+      if (interval) window.clearInterval(interval);
+      prefersReducedMotion.removeEventListener("change", startBlink);
       observer.disconnect();
     };
   }, []);

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -22,12 +22,12 @@ export function ThemeToggle() {
       aria-label="Toggle theme"
     >
       {theme === "dark" ? (
-        <svg className="terminal-toggle-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <circle cx="12" cy="12" r="4" />
           <path d="M12 2v3M12 19v3M4.93 4.93l2.12 2.12M16.95 16.95l2.12 2.12M2 12h3M19 12h3M4.93 19.07l2.12-2.12M16.95 7.05l2.12-2.12" />
         </svg>
       ) : (
-        <svg className="terminal-toggle-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M21 12.5A8.5 8.5 0 1 1 11.5 3a7 7 0 0 0 9.5 9.5z" />
         </svg>
       )}

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -3,11 +3,7 @@
 import * as React from "react"
 import { useTheme } from "next-themes"
 
-type ThemeToggleProps = {
-  variant?: "terminal" | "legacy"
-}
-
-export function ThemeToggle({ variant = "terminal" }: ThemeToggleProps) {
+export function ThemeToggle() {
   const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = React.useState(false)
 
@@ -16,18 +12,13 @@ export function ThemeToggle({ variant = "terminal" }: ThemeToggleProps) {
   }, [])
 
   if (!mounted) {
-    return <div className="w-5 h-5" /> // Placeholder to prevent layout shift
+    return <div className="terminal-icon-button" style={{ visibility: "hidden" }} />
   }
-
-  const buttonClass =
-    variant === "legacy"
-      ? "p-2 rounded-md hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
-      : "terminal-icon-button"
 
   return (
     <button
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      className={buttonClass}
+      className="terminal-icon-button"
       aria-label="Toggle theme"
     >
       {theme === "dark" ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -591,7 +591,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-3);
-    padding: var(--space-2) 0 var(--space-3);
+    padding: var(--space-2) 0 var(--space-1);
   }
 
   .terminal-prompt {

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================================
+   BASE LAYER -- reset, palette, typography
+   ============================================================ */
 @layer base {
   html {
     box-sizing: border-box;
@@ -22,12 +25,27 @@
     flex-direction: column;
   }
 
+  /* --------------------------------------------------------
+     Design tokens
+     -------------------------------------------------------- */
   html[data-layout="terminal"] {
     --font-size: 1rem;
     --line-height: 1.54;
     --radius: 0px;
     --control-height: 36px;
     --control-padding-x: 10px;
+
+    /* spacing scale (based on line-height multiples) */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.5rem;
+    --space-6: 2rem;
+    --space-7: 3rem;
+    --space-8: 4rem;
+
+    /* light palette (amber default kept for reference; blue is default via data-palette) */
     --background: #f5f1e8;
     --foreground: #1a170f;
     --accent: #b07d1d;
@@ -53,6 +71,15 @@
     --accent-soft: color-mix(in srgb, var(--accent) 22%, transparent);
     --scanline: rgba(0, 0, 0, 0.25);
     --noise-opacity: 0.08;
+  }
+
+  /* palette overrides -- amber light adjusted for 4.5:1 contrast */
+  html[data-layout="terminal"][data-palette="amber"] {
+    --accent: #8a6200;
+  }
+
+  html.dark[data-layout="terminal"][data-palette="amber"] {
+    --accent: #eec35e;
   }
 
   html[data-layout="terminal"][data-palette="green"] {
@@ -95,6 +122,9 @@
     --accent: #d88cff;
   }
 
+  /* --------------------------------------------------------
+     Body & CRT effects
+     -------------------------------------------------------- */
   html[data-layout="terminal"] body {
     font-family: "Fira Code", "JetBrains Mono", Monaco, Consolas, "Ubuntu Mono", monospace;
     font-size: var(--font-size);
@@ -114,6 +144,7 @@
       radial-gradient(circle at 82% 12%, color-mix(in srgb, var(--accent) 10%, transparent), transparent 50%),
       linear-gradient(180deg, color-mix(in srgb, var(--background) 88%, #000000), var(--background));
     background-attachment: fixed;
+    transition: background-color 0.18s linear, color 0.18s linear;
   }
 
   html[data-layout="terminal"] body::before {
@@ -148,25 +179,43 @@
     z-index: 0;
   }
 
+  /* --------------------------------------------------------
+     Headings
+     -------------------------------------------------------- */
   html[data-layout="terminal"] h1 {
     font-size: calc(var(--font-size) * 1.55);
+    font-weight: 700;
     letter-spacing: 0;
   }
 
   html[data-layout="terminal"] h2 {
     font-size: calc(var(--font-size) * 1.35);
+    font-weight: 700;
     letter-spacing: 0;
   }
 
   html[data-layout="terminal"] h3 {
     font-size: calc(var(--font-size) * 1.15);
+    font-weight: 600;
     letter-spacing: 0;
   }
 
-  html[data-layout="terminal"] h4,
-  html[data-layout="terminal"] h5,
+  html[data-layout="terminal"] h4 {
+    font-size: var(--font-size);
+    font-weight: 600;
+    letter-spacing: 0;
+  }
+
+  html[data-layout="terminal"] h5 {
+    font-size: var(--font-size);
+    font-weight: 500;
+    letter-spacing: 0;
+  }
+
   html[data-layout="terminal"] h6 {
-    font-size: calc(var(--font-size) * 1);
+    font-size: var(--font-size);
+    font-weight: 500;
+    font-style: italic;
     letter-spacing: 0;
   }
 
@@ -179,17 +228,20 @@
   html[data-layout="terminal"] p,
   html[data-layout="terminal"] ul,
   html[data-layout="terminal"] ol,
-  html[data-layout="terminal"] img,
   html[data-layout="terminal"] figure,
   html[data-layout="terminal"] video,
   html[data-layout="terminal"] table,
   html[data-layout="terminal"] pre {
-    margin: 1rem 0;
+    margin: var(--space-4) 0;
   }
 
+  /* --------------------------------------------------------
+     Inline elements
+     -------------------------------------------------------- */
   html[data-layout="terminal"] a {
     color: var(--accent);
     text-decoration: none;
+    transition: color 0.15s linear;
   }
 
   html[data-layout="terminal"] a:hover {
@@ -223,7 +275,7 @@
   html[data-layout="terminal"] input:focus-visible,
   html[data-layout="terminal"] select:focus-visible,
   html[data-layout="terminal"] textarea:focus-visible {
-    outline: 1px solid var(--accent);
+    outline: 2px solid var(--accent);
     outline-offset: 2px;
   }
 
@@ -256,6 +308,9 @@
     padding-right: calc(var(--control-padding-x) + 18px);
   }
 
+  /* --------------------------------------------------------
+     Lists
+     -------------------------------------------------------- */
   html[data-layout="terminal"] ul {
     list-style: none;
     margin-left: 2ch;
@@ -279,10 +334,13 @@
     padding: 0;
   }
 
+  /* --------------------------------------------------------
+     Code blocks
+     -------------------------------------------------------- */
   html[data-layout="terminal"] pre {
     background: var(--surface);
     border: 1px solid var(--border);
-    padding: 16px;
+    padding: var(--space-4);
     overflow-x: auto;
   }
 
@@ -299,26 +357,55 @@
     padding: 0;
   }
 
-  html[data-layout="terminal"] img {
+  /* --------------------------------------------------------
+     Blockquote
+     -------------------------------------------------------- */
+  html[data-layout="terminal"] blockquote {
+    margin: var(--space-4) 0;
+    padding: var(--space-2) var(--space-4);
+    border-left: 3px solid var(--accent);
+    color: var(--muted);
+  }
+
+  html[data-layout="terminal"] blockquote p {
+    margin: var(--space-2) 0;
+  }
+
+  /* --------------------------------------------------------
+     Images (scoped to content areas via .site-main)
+     -------------------------------------------------------- */
+  html[data-layout="terminal"] .site-main img {
     max-width: 100%;
     border: 6px solid var(--accent);
     padding: 6px;
   }
 
+  /* --------------------------------------------------------
+     Selection & motion
+     -------------------------------------------------------- */
   html[data-layout="terminal"] ::selection {
     background: var(--accent);
     color: var(--background);
   }
 
   @media (prefers-reduced-motion: reduce) {
-    html[data-layout="terminal"] body::before,
-    html[data-layout="terminal"] body::after {
-      animation: none;
+    html[data-layout="terminal"] *,
+    html[data-layout="terminal"] *::before,
+    html[data-layout="terminal"] *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
     }
   }
 }
 
+/* ============================================================
+   COMPONENTS LAYER -- site shell, terminal components
+   ============================================================ */
 @layer components {
+  /* --------------------------------------------------------
+     Site frame (terminal window)
+     -------------------------------------------------------- */
   .site-frame {
     position: relative;
     z-index: 1;
@@ -326,36 +413,81 @@
     display: flex;
     flex-direction: column;
     width: 100%;
+    transition: border-color 0.18s linear;
   }
 
   html[data-layout="terminal"] .site-frame {
     max-width: 54rem;
     min-height: 100vh;
     margin: 0 auto;
-    padding: 40px 40px 24px;
+    padding: 0 var(--space-6) var(--space-5);
+    border-left: 1px solid color-mix(in srgb, var(--accent) 12%, transparent);
     border-right: 1px solid color-mix(in srgb, var(--accent) 12%, transparent);
   }
 
+  /* --------------------------------------------------------
+     Title bar (terminal window chrome)
+     -------------------------------------------------------- */
+  .site-titlebar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-2) var(--space-3);
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+    transition: background-color 0.18s linear, border-color 0.18s linear;
+  }
+
+  .site-window-dots {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+  }
+
+  .site-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+  }
+
+  .site-dot--close {
+    background: #ff5f57;
+  }
+
+  .site-dot--minimize {
+    background: #febc2e;
+  }
+
+  .site-dot--maximize {
+    background: #28c840;
+  }
+
+  .site-titlebar-path {
+    flex: 1;
+    font-size: 0.75rem;
+    color: var(--muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-align: center;
+  }
+
+  .site-titlebar-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    flex-shrink: 0;
+  }
+
+  /* --------------------------------------------------------
+     Header & nav
+     -------------------------------------------------------- */
   .site-header {
-    margin-bottom: 24px;
-    width: 100%;
-  }
-
-  .site-nav {
     display: flex;
     align-items: center;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 16px;
-  }
-
-  .site-nav-left {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 18px;
-    flex: 0 1 auto;
-    min-width: 0;
+    gap: var(--space-5);
+    padding: var(--space-4) 0;
+    border-bottom: 1px solid var(--border);
   }
 
   .site-logo {
@@ -369,10 +501,15 @@
     letter-spacing: 0.08em;
     text-transform: uppercase;
     position: relative;
+    transition: background-color 0.18s linear;
   }
 
   html[data-layout="terminal"] a.site-logo {
     color: var(--background);
+  }
+
+  html[data-layout="terminal"] a.site-logo:hover {
+    text-decoration: none;
   }
 
   html[data-layout="terminal"] .site-logo::after {
@@ -385,9 +522,19 @@
     animation: cursor-blink 1.2s steps(2, start) infinite;
   }
 
+  .site-nav {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+  }
+
   .site-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3ch;
     color: var(--foreground);
     text-decoration: none;
+    transition: color 0.15s linear;
   }
 
   .site-link:hover {
@@ -395,25 +542,87 @@
     text-decoration: underline;
   }
 
-  .site-divider {
-    flex: 1 1 140px;
-    height: 32px;
-    min-width: 80px;
-    background: repeating-linear-gradient(90deg, var(--accent), var(--accent) 2px, transparent 0, transparent 10px);
-    opacity: 0.7;
+  .site-link--active {
+    color: var(--accent);
+    font-weight: 600;
   }
 
-  .site-actions {
+  .site-link--active:hover {
+    text-decoration: none;
+  }
+
+  .site-link-indicator {
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  /* --------------------------------------------------------
+     Skip link (accessibility)
+     -------------------------------------------------------- */
+  .skip-link {
+    position: absolute;
+    left: -9999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    z-index: 100;
+    padding: var(--space-2) var(--space-4);
+    background: var(--accent);
+    color: var(--background);
+    font-weight: 600;
+  }
+
+  .skip-link:focus {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: auto;
+    height: auto;
+    text-decoration: none;
+  }
+
+  /* --------------------------------------------------------
+     Main content
+     -------------------------------------------------------- */
+  .site-main {
+    flex: 1;
+    width: 100%;
+    padding: var(--space-5) 0;
+  }
+
+  /* --------------------------------------------------------
+     Status bar (footer)
+     -------------------------------------------------------- */
+  .site-statusbar {
     display: flex;
     align-items: center;
-    gap: 10px;
-    flex: 0 0 auto;
+    justify-content: space-between;
+    gap: var(--space-4);
+    padding: var(--space-2) var(--space-3);
+    border-top: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--muted);
+    font-size: 0.75rem;
+    transition: background-color 0.18s linear, border-color 0.18s linear;
   }
 
+  .site-statusbar-left {
+    display: flex;
+    gap: var(--space-4);
+  }
+
+  .site-statusbar-right {
+    white-space: nowrap;
+  }
+
+  /* --------------------------------------------------------
+     Palette select
+     -------------------------------------------------------- */
   .site-palette {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
+    gap: var(--space-2);
   }
 
   .site-palette__label {
@@ -423,36 +632,14 @@
     color: var(--muted);
   }
 
-  .site-main {
-    flex: 1;
-    width: 100%;
-  }
-
-  .site-footer {
-    margin-top: 32px;
-    padding-top: 24px;
-    border-top: 1px solid var(--border);
-    color: var(--muted);
-    text-align: center;
-    width: 100%;
-  }
-
-  .site-footer p {
-    margin: 12px 0 0;
-  }
-
-  .site-footer-links {
-    display: flex;
-    justify-content: center;
-    gap: 20px;
-    flex-wrap: wrap;
-  }
-
+  /* --------------------------------------------------------
+     Terminal hero (page headers)
+     -------------------------------------------------------- */
   .terminal-hero {
     display: flex;
     flex-direction: column;
-    gap: 12px;
-    padding: 8px 0 12px;
+    gap: var(--space-3);
+    padding: var(--space-2) 0 var(--space-3);
   }
 
   .terminal-prompt {
@@ -467,18 +654,9 @@
     position: relative;
     color: var(--accent);
     margin: 0;
-    padding-bottom: 14px;
+    padding-bottom: var(--space-3);
     border-bottom: 3px dotted var(--accent);
     text-shadow: 0 0 18px color-mix(in srgb, var(--accent) 35%, transparent);
-  }
-
-  .terminal-title::after {
-    content: "";
-    position: absolute;
-    bottom: 2px;
-    left: 0;
-    width: 100%;
-    border-bottom: 3px dotted var(--accent);
   }
 
   .terminal-lead {
@@ -486,23 +664,57 @@
     max-width: 42ch;
   }
 
+  /* MOTD (home page) */
+  .terminal-motd {
+    color: var(--accent);
+    font-size: 0.65rem;
+    line-height: 1.2;
+    border: none;
+    background: transparent;
+    padding: 0;
+    margin: var(--space-4) 0;
+    overflow-x: auto;
+  }
+
+  .terminal-motd-info {
+    margin: var(--space-4) 0;
+  }
+
+  .terminal-motd-info p {
+    margin: var(--space-1) 0;
+  }
+
+  .terminal-motd-links {
+    margin: var(--space-5) 0;
+  }
+
+  /* Blog list */
+  .terminal-blog-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  /* --------------------------------------------------------
+     Terminal grid / cards
+     -------------------------------------------------------- */
   .terminal-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 10px;
+    gap: var(--space-3);
   }
 
   .terminal-card {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    padding: 12px 12px 10px;
+    gap: var(--space-1);
+    padding: var(--space-3);
     background: color-mix(in srgb, var(--background) 92%, var(--accent) 8%);
     border: 1px solid var(--border);
     text-decoration: none;
     color: inherit;
     position: relative;
-    transition: background 0.2s linear, border-color 0.2s linear, transform 0.2s ease;
+    transition: background 0.15s linear, border-color 0.15s linear, transform 0.15s linear;
   }
 
   .terminal-card::before {
@@ -517,10 +729,12 @@
     margin: 0;
   }
 
-  .terminal-card:hover {
+  .terminal-card:hover,
+  .terminal-card:focus-visible {
     background: color-mix(in srgb, var(--accent) 10%, var(--surface));
     border-color: var(--accent);
     transform: translateY(-2px);
+    text-decoration: none;
   }
 
   .terminal-card-header {
@@ -562,20 +776,23 @@
     line-height: 1.3;
   }
 
+  /* --------------------------------------------------------
+     Terminal content elements
+     -------------------------------------------------------- */
   .terminal-section {
     color: var(--accent);
     border-bottom: 2px dotted var(--accent);
-    padding-bottom: 6px;
-    margin-top: 24px;
+    padding-bottom: var(--space-2);
+    margin-top: var(--space-5);
   }
 
   .terminal-paragraph {
     color: var(--foreground);
-    margin: 12px 0;
+    margin: var(--space-3) 0;
   }
 
   .terminal-list {
-    margin: 12px 0 12px 2ch;
+    margin: var(--space-3) 0 var(--space-3) 2ch;
   }
 
   .terminal-link {
@@ -585,16 +802,19 @@
     text-underline-offset: 3px;
   }
 
+  /* --------------------------------------------------------
+     Terminal panels
+     -------------------------------------------------------- */
   .terminal-panel {
     background: var(--surface);
     border: 1px solid var(--border);
-    padding: 20px;
+    padding: var(--space-5);
   }
 
   .terminal-panel-header {
     background: var(--surface-strong);
     border-bottom: 1px solid var(--border);
-    padding: 12px 20px;
+    padding: var(--space-3) var(--space-5);
   }
 
   .terminal-rows > * + * {
@@ -609,6 +829,9 @@
     background: color-mix(in srgb, var(--accent) 8%, transparent);
   }
 
+  /* --------------------------------------------------------
+     Terminal utility classes
+     -------------------------------------------------------- */
   .terminal-muted {
     color: var(--muted);
   }
@@ -617,18 +840,21 @@
     color: var(--accent);
   }
 
+  /* --------------------------------------------------------
+     Terminal buttons
+     -------------------------------------------------------- */
   .terminal-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    gap: 8px;
+    gap: var(--space-2);
     border: 2px solid var(--accent);
     color: var(--accent);
     background: transparent;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.08em;
-    padding: 8px 16px;
+    padding: var(--space-2) var(--space-4);
     cursor: pointer;
     transition: background 0.15s linear, border-color 0.15s linear, color 0.15s linear;
   }
@@ -649,6 +875,9 @@
     background: transparent;
   }
 
+  /* --------------------------------------------------------
+     Icon button (theme toggle, etc.)
+     -------------------------------------------------------- */
   .terminal-icon-button {
     border: 1px solid var(--border);
     color: var(--accent);
@@ -661,6 +890,7 @@
     line-height: 0;
     background: transparent;
     overflow: visible;
+    transition: background 0.15s linear, border-color 0.15s linear, color 0.15s linear;
   }
 
   .terminal-icon-button svg {
@@ -681,6 +911,9 @@
     background: color-mix(in srgb, var(--accent) 12%, transparent);
   }
 
+  /* --------------------------------------------------------
+     Danger styling
+     -------------------------------------------------------- */
   .terminal-danger {
     color: #d05757;
     border-color: color-mix(in srgb, #d05757 35%, var(--border));
@@ -692,6 +925,9 @@
     background: color-mix(in srgb, #d05757 12%, transparent);
   }
 
+  /* --------------------------------------------------------
+     Form elements
+     -------------------------------------------------------- */
   .terminal-select {
     min-width: 140px;
     text-transform: uppercase;
@@ -711,6 +947,9 @@
     height: var(--control-height);
   }
 
+  /* --------------------------------------------------------
+     Badge, alert, divider
+     -------------------------------------------------------- */
   .terminal-badge {
     border: 1px solid var(--border);
     padding: 2px 6px;
@@ -722,8 +961,8 @@
 
   .terminal-alert {
     border: 1px solid;
-    padding: 12px 16px;
-    margin-bottom: 16px;
+    padding: var(--space-3) var(--space-4);
+    margin-bottom: var(--space-4);
   }
 
   .terminal-alert--error {
@@ -742,6 +981,9 @@
     border-top: 1px solid var(--border);
   }
 
+  /* --------------------------------------------------------
+     Animations
+     -------------------------------------------------------- */
   @keyframes cursor-blink {
     0%,
     50% {
@@ -753,52 +995,44 @@
     }
   }
 
+  /* --------------------------------------------------------
+     Mobile
+     -------------------------------------------------------- */
   @media (max-width: 720px) {
     html[data-layout="terminal"] .site-frame {
-      padding: 24px 20px;
+      padding: 0 var(--space-3) var(--space-3);
+      border-left: none;
       border-right: none;
     }
 
-    .site-actions {
-      order: 3;
-      width: 100%;
-      justify-content: flex-start;
+    .site-titlebar {
+      padding: var(--space-2);
     }
 
-    .site-nav-left {
-      order: 1;
-      width: 100%;
+    .site-titlebar-path {
+      display: none;
     }
 
-    .site-divider {
-      order: 2;
-      width: 100%;
-      min-width: 100%;
-      height: 16px;
+    .site-header {
+      flex-wrap: wrap;
+      gap: var(--space-3);
     }
 
     .site-palette__label {
       display: none;
     }
-  }
 
-  @media (prefers-reduced-motion: reduce) {
-    html[data-layout="terminal"] .site-logo::after {
-      animation: none;
+    .site-statusbar {
+      flex-wrap: wrap;
+      font-size: 0.65rem;
+      gap: var(--space-2);
     }
   }
 }
 
-@layer utilities {
-  .text-muted {
-    color: var(--muted);
-  }
-
-  .text-accent {
-    color: var(--accent);
-  }
-}
-
+/* ============================================================
+   PRINT
+   ============================================================ */
 @media print {
   html[data-layout="terminal"] body {
     background: #ffffff !important;
@@ -815,5 +1049,12 @@
     border: none;
     padding: 0;
     margin: 0;
+  }
+
+  .site-titlebar,
+  .site-header,
+  .site-statusbar,
+  .skip-link {
+    display: none !important;
   }
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -376,8 +376,6 @@
      -------------------------------------------------------- */
   html[data-layout="terminal"] .site-main img {
     max-width: 100%;
-    border: 6px solid var(--accent);
-    padding: 6px;
   }
 
   /* --------------------------------------------------------
@@ -426,60 +424,6 @@
   }
 
   /* --------------------------------------------------------
-     Title bar (terminal window chrome)
-     -------------------------------------------------------- */
-  .site-titlebar {
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    padding: var(--space-2) var(--space-3);
-    border-bottom: 1px solid var(--border);
-    background: var(--surface);
-    transition: background-color 0.18s linear, border-color 0.18s linear;
-  }
-
-  .site-window-dots {
-    display: flex;
-    gap: 6px;
-    flex-shrink: 0;
-  }
-
-  .site-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-  }
-
-  .site-dot--close {
-    background: #ff5f57;
-  }
-
-  .site-dot--minimize {
-    background: #febc2e;
-  }
-
-  .site-dot--maximize {
-    background: #28c840;
-  }
-
-  .site-titlebar-path {
-    flex: 1;
-    font-size: 0.75rem;
-    color: var(--muted);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-align: center;
-  }
-
-  .site-titlebar-controls {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    flex-shrink: 0;
-  }
-
-  /* --------------------------------------------------------
      Header & nav
      -------------------------------------------------------- */
   .site-header {
@@ -488,6 +432,14 @@
     gap: var(--space-5);
     padding: var(--space-4) 0;
     border-bottom: 1px solid var(--border);
+  }
+
+  .site-header-controls {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-left: auto;
+    flex-shrink: 0;
   }
 
   .site-logo {
@@ -664,30 +616,6 @@
     max-width: 42ch;
   }
 
-  /* MOTD (home page) */
-  .terminal-motd {
-    color: var(--accent);
-    font-size: 0.65rem;
-    line-height: 1.2;
-    border: none;
-    background: transparent;
-    padding: 0;
-    margin: var(--space-4) 0;
-    overflow-x: auto;
-  }
-
-  .terminal-motd-info {
-    margin: var(--space-4) 0;
-  }
-
-  .terminal-motd-info p {
-    margin: var(--space-1) 0;
-  }
-
-  .terminal-motd-links {
-    margin: var(--space-5) 0;
-  }
-
   /* Blog list */
   .terminal-blog-list {
     display: flex;
@@ -708,7 +636,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--space-1);
-    padding: var(--space-3);
+    padding: var(--space-2) var(--space-3);
     background: color-mix(in srgb, var(--background) 92%, var(--accent) 8%);
     border: 1px solid var(--border);
     text-decoration: none;
@@ -717,15 +645,7 @@
     transition: background 0.15s linear, border-color 0.15s linear, transform 0.15s linear;
   }
 
-  .terminal-card::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
-    pointer-events: none;
-  }
-
-  .terminal-card > * {
+  html[data-layout="terminal"] .terminal-card > * {
     margin: 0;
   }
 
@@ -878,7 +798,7 @@
   /* --------------------------------------------------------
      Icon button (theme toggle, etc.)
      -------------------------------------------------------- */
-  .terminal-icon-button {
+  html[data-layout="terminal"] button.terminal-icon-button {
     border: 1px solid var(--border);
     color: var(--accent);
     width: var(--control-height);
@@ -897,12 +817,6 @@
     width: 18px;
     height: 18px;
     display: block;
-    stroke: currentColor;
-    fill: none;
-  }
-
-  .terminal-toggle-icon {
-    stroke-width: 1.8;
   }
 
   .terminal-icon-button:hover {
@@ -1005,14 +919,6 @@
       border-right: none;
     }
 
-    .site-titlebar {
-      padding: var(--space-2);
-    }
-
-    .site-titlebar-path {
-      display: none;
-    }
-
     .site-header {
       flex-wrap: wrap;
       gap: var(--space-3);
@@ -1051,7 +957,6 @@
     margin: 0;
   }
 
-  .site-titlebar,
   .site-header,
   .site-statusbar,
   .skip-link {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,10 +4,31 @@ import { ThemeProvider } from "./providers";
 import { SiteShell } from "./components/site-shell";
 import { TerminalFavicon } from "./components/terminal-favicon";
 
+const siteUrl = "https://atqamz.github.io";
+
 export const metadata: Metadata = {
-  title: "Atqa Munzir's terminal",
-  description: "Welcome to my personal website",
+  title: {
+    default: "Atqa Munzir",
+    template: "%s | Atqa Munzir",
+  },
+  description: "Game programmer, full-stack developer. Personal terminal.",
+  metadataBase: new URL(siteUrl),
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: "Atqa Munzir",
+    title: "Atqa Munzir",
+    description: "Game programmer, full-stack developer. Personal terminal.",
+    url: siteUrl,
+  },
+  twitter: {
+    card: "summary",
+    title: "Atqa Munzir",
+    description: "Game programmer, full-stack developer. Personal terminal.",
+  },
 };
+
+const paletteInitScript = `(function(){try{var p=localStorage.getItem("terminal-palette");if(p&&["amber","blue","cyan","green","magenta","red"].indexOf(p)!==-1){document.documentElement.dataset.palette=p}}catch(e){}})()`;
 
 export default function RootLayout({
   children,
@@ -15,8 +36,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning data-layout="terminal" data-palette="amber">
-      <body className="min-h-screen flex flex-col">
+    <html lang="en" suppressHydrationWarning data-layout="terminal" data-palette="blue">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: paletteInitScript }} />
+      </head>
+      <body>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
           <TerminalFavicon />
           <SiteShell>{children}</SiteShell>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,10 +1,16 @@
+import type { Metadata } from "next";
 import Link from 'next/link'
- 
+
+export const metadata: Metadata = {
+  title: "Not Found",
+  robots: { index: false, follow: false },
+};
+
 export default function NotFound() {
   return (
     <div className="terminal-hero">
       <p className="terminal-prompt">status 404</p>
-      <h2 className="terminal-title">Not Found</h2>
+      <h1 className="terminal-title">Not Found</h1>
       <p className="terminal-lead">Could not find requested resource.</p>
       <div>
         <Link href="/" className="terminal-button terminal-button--ghost">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,15 +17,12 @@ export default function Home() {
         <h1 className="terminal-title">welcome</h1>
       </section>
 
-
-<div className="terminal-motd-info">
-        <p className="terminal-paragraph">
+      <p className="terminal-paragraph">
           game programmer &middot; full-stack developer &middot; based in indonesia
         </p>
         <p className="terminal-paragraph terminal-muted">
           i build games, backend systems, and occasionally break things on purpose.
         </p>
-      </div>
 
       <section className="terminal-motd-links">
         <p className="terminal-prompt">links</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,21 +17,8 @@ export default function Home() {
         <h1 className="terminal-title">welcome</h1>
       </section>
 
-      <pre className="terminal-motd" aria-label="Message of the day">
-{`  ___  _
- / _ \\| |_ __ _  __ _
-| |_| | __/ _\` |/ _\` |
-|  _  | || (_| | (_| |
-|_| |_|\\__\\__, |\\__,_|
-             |_|
-  __  __                  _
- |  \\/  |_   _ _ __  ____(_)_ __
- | |\\/| | | | | '_ \\|_  / | '__|
- | |  | | |_| | | | |/ /| | |
- |_|  |_|\\__,_|_| |_/___|_|_|   `}
-      </pre>
 
-      <div className="terminal-motd-info">
+<div className="terminal-motd-info">
         <p className="terminal-paragraph">
           game programmer &middot; full-stack developer &middot; based in indonesia
         </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,74 @@
+import type { Metadata } from "next";
 import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: "Atqa Munzir",
+  description: "Game programmer, full-stack developer. Welcome to my terminal.",
+  openGraph: {
+    title: "Atqa Munzir",
+    description: "Game programmer, full-stack developer. Welcome to my terminal.",
+  },
+};
 
 export default function Home() {
   return (
-    <div className="space-y-6">
+    <div>
       <section className="terminal-hero">
-        <h1 className="terminal-title">/home</h1>
+        <h1 className="terminal-title">welcome</h1>
       </section>
 
-      <div className="terminal-grid">
-        <Link href="/blog" className="terminal-card">
-          <h2 className="terminal-card-title">Blog</h2>
-          <p className="terminal-card-desc">Read my words.</p>
-        </Link>
+      <pre className="terminal-motd" aria-label="Message of the day">
+{`  ___  _
+ / _ \\| |_ __ _  __ _
+| |_| | __/ _\` |/ _\` |
+|  _  | || (_| | (_| |
+|_| |_|\\__\\__, |\\__,_|
+             |_|
+  __  __                  _
+ |  \\/  |_   _ _ __  ____(_)_ __
+ | |\\/| | | | | '_ \\|_  / | '__|
+ | |  | | |_| | | | |/ /| | |
+ |_|  |_|\\__,_|_| |_/___|_|_|   `}
+      </pre>
 
-        <Link href="/resume" className="terminal-card">
-          <h2 className="terminal-card-title">Resume</h2>
-          <p className="terminal-card-desc">Check out my professional journeys.</p>
-        </Link>
+      <div className="terminal-motd-info">
+        <p className="terminal-paragraph">
+          game programmer &middot; full-stack developer &middot; based in indonesia
+        </p>
+        <p className="terminal-paragraph terminal-muted">
+          i build games, backend systems, and occasionally break things on purpose.
+        </p>
       </div>
+
+      <section className="terminal-motd-links">
+        <p className="terminal-prompt">links</p>
+        <ul className="terminal-list">
+          <li><a href="https://github.com/atqamz" target="_blank" rel="noopener noreferrer" className="terminal-link">github.com/atqamz</a></li>
+          <li><a href="https://linkedin.com/in/atqamunzir" target="_blank" rel="noopener noreferrer" className="terminal-link">linkedin.com/in/atqamunzir</a></li>
+          <li><a href="mailto:atqamz@gmail.com" className="terminal-link">atqamz@gmail.com</a></li>
+        </ul>
+      </section>
+
+      <section>
+        <p className="terminal-prompt">ls -la ~/</p>
+        <div className="terminal-grid">
+          <Link href="/blog" className="terminal-card">
+            <div className="terminal-card-header">
+              <span className="terminal-card-kicker">dir</span>
+            </div>
+            <h2 className="terminal-card-title">blog</h2>
+            <p className="terminal-card-desc">thoughts, notes, and the occasional tutorial.</p>
+          </Link>
+
+          <Link href="/resume" className="terminal-card">
+            <div className="terminal-card-header">
+              <span className="terminal-card-kicker">dir</span>
+            </div>
+            <h2 className="terminal-card-title">resume</h2>
+            <p className="terminal-card-desc">professional experience and education.</p>
+          </Link>
+        </div>
+      </section>
     </div>
   );
 }

--- a/app/resume/ResumeRenderer.tsx
+++ b/app/resume/ResumeRenderer.tsx
@@ -1,21 +1,9 @@
-"use client";
-
 import type { ResumeData } from "./types";
 import styles from "./resume.module.css";
 
 export default function ResumeRenderer({ data }: { data: ResumeData }) {
   return (
     <section className={styles.page}>
-      <div className={styles.toolbar}>
-        <button
-          className="terminal-button"
-          onClick={() => window.print()}
-          type="button"
-        >
-          print / download pdf
-        </button>
-      </div>
-
       <section className={styles.header}>
         <h1 className={styles.name}>{data.name}</h1>
         <p className={styles.role}>{data.role}</p>

--- a/app/resume/ResumeRenderer.tsx
+++ b/app/resume/ResumeRenderer.tsx
@@ -1,13 +1,34 @@
+"use client";
+
 import type { ResumeData } from "./types";
 import styles from "./resume.module.css";
 
 export default function ResumeRenderer({ data }: { data: ResumeData }) {
   return (
     <section className={styles.page}>
+      <div className={styles.toolbar}>
+        <button
+          className="terminal-button"
+          onClick={() => window.print()}
+          type="button"
+        >
+          print / download pdf
+        </button>
+      </div>
+
       <section className={styles.header}>
         <h1 className={styles.name}>{data.name}</h1>
         <p className={styles.role}>{data.role}</p>
-        <p className={styles.contact}>{data.contact}</p>
+        <p className={styles.contact}>
+          {data.contact.map((item, i) => (
+            <span key={item.href}>
+              {i > 0 && <span className={styles.contactSep}> | </span>}
+              <a href={item.href} target="_blank" rel="noopener noreferrer">
+                {item.label}
+              </a>
+            </span>
+          ))}
+        </p>
       </section>
 
       <section className={styles.section}>

--- a/app/resume/data/base.ts
+++ b/app/resume/data/base.ts
@@ -3,8 +3,11 @@ import type { ResumeData } from "../types";
 const base: ResumeData = {
   name: "ATQA MUNZIR",
   role: "Game Programmer",
-  contact:
-    "atqamz@gmail.com | linkedin.com/in/atqamunzir | bit.ly/atqamunzir_portfolio | github.com/atqamz",
+  contact: [
+    { label: "atqamz@gmail.com", href: "mailto:atqamz@gmail.com" },
+    { label: "linkedin.com/in/atqamunzir", href: "https://linkedin.com/in/atqamunzir" },
+    { label: "github.com/atqamz", href: "https://github.com/atqamz" },
+  ],
   summary:
     "A skilled Coder proficient in C#, Unity, C++, Unreal Engine. With hands-on experience in both game programming and full-stack backend development. Demonstrated ability to lead teams and deliver critical in-game systems, such as cross-platform payment utilities and online services. Experienced in building and maintaining CI/CD pipelines to streamline development. Eager to contribute technical expertise and a passion for gaming to a forward-thinking team.",
   sections: [
@@ -16,7 +19,6 @@ const base: ResumeData = {
           role: "Junior Game Programmer - Full-time (Remote)",
           location: "Singapore",
           date: "Jul 2025 - Present",
-          items: ["I code stuff."],
         },
         {
           org: "Timedoor Academy",
@@ -34,7 +36,6 @@ const base: ResumeData = {
           role: "Cheerleader - Part-time (Remote)",
           location: "Surabaya, Indonesia",
           date: "Jan 2025 - Present",
-          items: ["I cheerlead stuff."],
         },
         {
           org: "Sepay Studio",

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,5 +1,15 @@
+import type { Metadata } from "next";
 import ResumeRenderer from "./ResumeRenderer";
 import base from "./data/base";
+
+export const metadata: Metadata = {
+  title: "Resume",
+  description: "Professional experience and education of Atqa Munzir.",
+  openGraph: {
+    title: "Resume | Atqa Munzir",
+    description: "Professional experience and education of Atqa Munzir.",
+  },
+};
 
 export default function ResumePage() {
   return (

--- a/app/resume/resume.module.css
+++ b/app/resume/resume.module.css
@@ -12,12 +12,6 @@
   color: var(--foreground, #e2e8f0);
 }
 
-.toolbar {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: var(--space-4, 1rem);
-}
-
 .header {
   margin-bottom: var(--space-4, 1rem);
 }
@@ -90,6 +84,7 @@
 
 .summary {
   margin: 0;
+  text-align: justify;
 }
 
 .entry {
@@ -154,6 +149,7 @@
   position: relative;
   padding-left: 1.4ch;
   margin-bottom: var(--space-1, 0.25rem);
+  text-align: justify;
 }
 
 .page .list li::before {
@@ -166,6 +162,12 @@
 
 :global(.dark) .page .list li::before {
   color: var(--accent, #cbd5f5);
+}
+
+.page p,
+.page h2,
+.page ul {
+  margin: 0;
 }
 
 /* ============================================================
@@ -187,13 +189,14 @@
     display: none !important;
   }
 
-  :global(main) {
+  :global(main),
+  :global(.site-main) {
     padding: 0;
     width: 100%;
   }
 
-  .toolbar {
-    display: none !important;
+  .entryHeader {
+    grid-template-columns: minmax(0, 1fr) 9rem;
   }
 
   .page {
@@ -202,7 +205,8 @@
     color: #111827 !important;
     padding: 0;
     max-width: none;
-    font-size: 0.98rem;
+    font-size: 0.95rem;
+    line-height: 1.35;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
@@ -212,18 +216,52 @@
     color: #111827 !important;
   }
 
+  .header {
+    margin-bottom: 0;
+  }
+
   .name {
     color: #111827 !important;
+    font-size: 1.5rem;
+  }
+
+  .role {
+    margin-top: 0;
+  }
+
+  .section {
+    margin-top: 0;
   }
 
   .sectionTitle {
     color: #111827 !important;
     border-bottom-color: #111827 !important;
     break-after: avoid;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+
+  .entry {
+    margin-top: 0;
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .entryOrg {
+    margin-bottom: 0;
+  }
+
+  .page .list {
+    margin-top: 0;
+  }
+
+  .page .list li {
+    margin-bottom: 0;
   }
 
   .contact {
     color: #1f2937 !important;
+    margin-top: 0;
   }
 
   .contact a {
@@ -233,11 +271,6 @@
 
   .contactSep {
     color: #6b7280 !important;
-  }
-
-  .entry {
-    break-inside: avoid;
-    page-break-inside: avoid;
   }
 
   .entryDate {

--- a/app/resume/resume.module.css
+++ b/app/resume/resume.module.css
@@ -1,12 +1,12 @@
 .page {
-  max-width: 900px;
+  max-width: 54rem;
   margin: 0 auto;
   background: var(--background, #ffffff);
   color: var(--foreground, #111827);
-  padding: 2rem 1.5rem 3rem;
-  font-family: "Calibri", "Arial", "Helvetica Neue", sans-serif;
-  font-size: 0.98rem;
-  line-height: 1.4;
+  padding: var(--space-4, 1rem) 0 var(--space-6, 2rem);
+  font-family: inherit;
+  font-size: 0.95rem;
+  line-height: 1.45;
 }
 
 :global(.dark) .page {
@@ -14,70 +14,94 @@
   color: var(--foreground, #e2e8f0);
 }
 
-@media (min-width: 768px) {
-  .page {
-    padding: 2.5rem 3rem 3.5rem;
-  }
+.toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: var(--space-4, 1rem);
 }
 
 .header {
-  margin-bottom: 1.4rem;
+  margin-bottom: var(--space-4, 1rem);
 }
 
 .name {
-  font-size: 2.25rem;
+  font-size: 2rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   font-weight: 700;
   margin: 0;
+  color: var(--accent, #1f2937);
+}
+
+:global(.dark) .name {
+  color: var(--accent, #e2e8f0);
 }
 
 .role {
-  font-size: 1.05rem;
+  font-size: 1rem;
   font-weight: 600;
-  margin: 0.25rem 0 0;
+  margin: var(--space-1, 0.25rem) 0 0;
 }
 
 .contact {
-  font-size: 0.92rem;
+  font-size: 0.85rem;
   color: var(--muted, #1f2937);
-  margin: 0.35rem 0 0;
+  margin: var(--space-2, 0.5rem) 0 0;
 }
 
 :global(.dark) .contact {
   color: var(--muted, #cbd5f5);
 }
 
+.contact a {
+  color: var(--accent, #245a9e);
+  text-decoration: none;
+}
+
+.contact a:hover {
+  text-decoration: underline;
+}
+
+:global(.dark) .contact a {
+  color: var(--accent, #6aa8ff);
+}
+
+.contactSep {
+  color: var(--muted, #9ca3af);
+}
+
 .section {
-  margin-top: 1.35rem;
+  margin-top: var(--space-4, 1rem);
 }
 
 .sectionTitle {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  margin: 0 0 0.5rem;
+  margin: 0 0 var(--space-2, 0.5rem);
   color: var(--accent, #1f2937);
+  border-bottom: 2px dotted var(--accent, #1f2937);
+  padding-bottom: var(--space-1, 0.25rem);
 }
 
 :global(.dark) .sectionTitle {
   color: var(--accent, #cbd5f5);
+  border-bottom-color: var(--accent, #cbd5f5);
 }
 
 .summary {
   margin: 0;
-  text-align: justify;
 }
 
 .entry {
-  margin-top: 0.85rem;
+  margin-top: var(--space-3, 0.75rem);
 }
 
 .entryHeader {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: 1rem;
+  gap: var(--space-4, 1rem);
 }
 
 @media (max-width: 767px) {
@@ -88,7 +112,7 @@
 
 .entryOrg {
   font-weight: 600;
-  margin: 0 0 0.15rem;
+  margin: 0 0 var(--space-1, 0.15rem);
 }
 
 .entryRole {
@@ -108,8 +132,8 @@
 
 .entryLocation {
   color: var(--muted, #374151);
-  font-size: 0.9rem;
-  margin: 0 0 0.2rem;
+  font-size: 0.88rem;
+  margin: 0 0 var(--space-1, 0.2rem);
 }
 
 :global(.dark) .entryLocation {
@@ -118,21 +142,20 @@
 
 .entryDate {
   font-weight: 600;
-  font-size: 0.9rem;
+  font-size: 0.88rem;
   margin: 0;
 }
 
 .page .list {
   list-style: none;
-  margin: 0.35rem 0 0;
+  margin: var(--space-2, 0.35rem) 0 0;
   padding: 0;
 }
 
 .page .list li {
   position: relative;
-  padding-left: 1.1rem;
-  margin-bottom: 0.25rem;
-  text-align: justify;
+  padding-left: 1.4ch;
+  margin-bottom: var(--space-1, 0.25rem);
 }
 
 .page .list li::before {
@@ -140,8 +163,16 @@
   position: absolute;
   left: 0;
   top: 0;
+  color: var(--accent, #1f2937);
 }
 
+:global(.dark) .page .list li::before {
+  color: var(--accent, #cbd5f5);
+}
+
+/* ============================================================
+   PRINT -- ATS-friendly, sans-serif
+   ============================================================ */
 @media print {
   @page {
     size: A4;
@@ -150,7 +181,11 @@
 
   :global(header),
   :global(footer),
-  :global(.terminal-hero) {
+  :global(.terminal-hero),
+  :global(.site-titlebar),
+  :global(.site-header),
+  :global(.site-statusbar),
+  :global(.skip-link) {
     display: none !important;
   }
 
@@ -159,10 +194,17 @@
     width: 100%;
   }
 
+  .toolbar {
+    display: none !important;
+  }
+
   .page {
+    font-family: "Calibri", "Arial", "Helvetica Neue", sans-serif;
     background: #ffffff !important;
     color: #111827 !important;
     padding: 0;
+    max-width: none;
+    font-size: 0.98rem;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
@@ -172,18 +214,32 @@
     color: #111827 !important;
   }
 
-  .entry {
-    break-inside: avoid;
-    page-break-inside: avoid;
+  .name {
+    color: #111827 !important;
   }
 
   .sectionTitle {
     color: #111827 !important;
+    border-bottom-color: #111827 !important;
     break-after: avoid;
   }
 
   .contact {
     color: #1f2937 !important;
+  }
+
+  .contact a {
+    color: #1f2937 !important;
+    text-decoration: none !important;
+  }
+
+  .contactSep {
+    color: #6b7280 !important;
+  }
+
+  .entry {
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 
   .entryDate {
@@ -192,5 +248,9 @@
 
   .entryLocation {
     color: #374151 !important;
+  }
+
+  .page .list li::before {
+    color: #111827 !important;
   }
 }

--- a/app/resume/resume.module.css
+++ b/app/resume/resume.module.css
@@ -1,7 +1,6 @@
 .page {
   max-width: 54rem;
   margin: 0 auto;
-  background: var(--background, #ffffff);
   color: var(--foreground, #111827);
   padding: var(--space-4, 1rem) 0 var(--space-6, 2rem);
   font-family: inherit;
@@ -10,7 +9,6 @@
 }
 
 :global(.dark) .page {
-  background: var(--background, #0f172a);
   color: var(--foreground, #e2e8f0);
 }
 

--- a/app/resume/types.ts
+++ b/app/resume/types.ts
@@ -1,3 +1,8 @@
+export interface ContactItem {
+  label: string;
+  href: string;
+}
+
 export interface ResumeEntry {
   org: string;
   role: string;
@@ -14,7 +19,7 @@ export interface ResumeSection {
 export interface ResumeData {
   name: string;
   role: string;
-  contact: string;
+  contact: ContactItem[];
   summary: string;
   sections: ResumeSection[];
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: "/short/",
+    },
+    sitemap: "https://atqamz.github.io/sitemap.xml",
+  };
+}

--- a/app/short/layout.tsx
+++ b/app/short/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Link Manager",
+  robots: { index: false, follow: false },
+};
+
+export default function ShortLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/app/short/page.tsx
+++ b/app/short/page.tsx
@@ -350,7 +350,7 @@ export default function ShortenerPage() {
                     </div>
                   </div>
                   
-                  <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-2">
                     <button
                       onClick={() => handleDeleteLink(link.filename)}
                       disabled={loading}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+import { posts } from "./blog/posts";
+
+export const dynamic = "force-static";
+
+const siteUrl = "https://atqamz.github.io";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const blogEntries = posts.map((post) => ({
+    url: `${siteUrl}/blog/${post.slug}/`,
+    lastModified: new Date(post.date),
+  }));
+
+  return [
+    { url: `${siteUrl}/`, lastModified: new Date() },
+    { url: `${siteUrl}/blog/`, lastModified: new Date() },
+    { url: `${siteUrl}/resume/`, lastModified: new Date() },
+    ...blogEntries,
+  ];
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -5,7 +5,6 @@ const cx = (...classes: Array<string | undefined>) =>
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
-    // Allows customizing built-in components, e.g. to add styling.
     h1: ({ children, className, ...props }) => (
       <h1 {...props} className={cx("terminal-title", className)}>
         {children}
@@ -15,6 +14,26 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
       <h2 {...props} className={cx("terminal-section", className)}>
         {children}
       </h2>
+    ),
+    h3: ({ children, className, ...props }) => (
+      <h3 {...props} className={cx("terminal-section", className)}>
+        {children}
+      </h3>
+    ),
+    h4: ({ children, className, ...props }) => (
+      <h4 {...props} className={cx("terminal-section", className)}>
+        {children}
+      </h4>
+    ),
+    h5: ({ children, className, ...props }) => (
+      <h5 {...props} className={cx("terminal-section", className)}>
+        {children}
+      </h5>
+    ),
+    h6: ({ children, className, ...props }) => (
+      <h6 {...props} className={cx("terminal-section", className)}>
+        {children}
+      </h6>
     ),
     p: ({ children, className, ...props }) => (
       <p {...props} className={cx("terminal-paragraph", className)}>
@@ -26,11 +45,32 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {children}
       </ul>
     ),
+    ol: ({ children, className, ...props }) => (
+      <ol {...props} className={className}>
+        {children}
+      </ol>
+    ),
     a: ({ children, className, ...props }) => (
       <a {...props} className={cx("terminal-link", className)}>
         {children}
       </a>
     ),
+    blockquote: ({ children, className, ...props }) => (
+      <blockquote {...props} className={className}>
+        {children}
+      </blockquote>
+    ),
+    pre: ({ children, className, ...props }) => (
+      <pre {...props} className={className}>
+        {children}
+      </pre>
+    ),
+    code: ({ children, className, ...props }) => (
+      <code {...props} className={className}>
+        {children}
+      </code>
+    ),
+    hr: (props) => <hr {...props} className="terminal-divider" />,
     ...components,
   }
 }


### PR DESCRIPTION
## Summary

- **Palette flash fix (#6):** inline `<script>` reads localStorage before first paint, aligned default to "blue", fixed ThemeToggle placeholder size mismatch
- **Terminal window shell (#7):** title bar with window dots, path display, symmetric borders, status bar footer replacing plain footer
- **Active nav (#8):** `usePathname()` for current route, `aria-current="page"`, `>` indicator, controls moved out of `<nav>` into title bar
- **Typography/spacing/cleanup (#12):** spacing scale (`--space-1`–`--space-8`), heading weight fixes, removed `.terminal-title` double border, normalized easing, scoped img border, complete MDX overrides (h3–h6, ol, blockquote, pre, code, hr), removed dead code
- **Accessibility (#13):** skip link, 404 `<h1>`, amber contrast fix (`#8a6200` for 4.5:1), 2px focus outline, card `:focus-visible`, comprehensive `prefers-reduced-motion`, visible delete button on `/short`
- **Home page MOTD (#9):** ASCII art banner, personal intro, social links, `ls -la` style directory cards
- **Resume terminal-ify (#11):** monospace on screen / Calibri for print, structured clickable contacts, print button, removed placeholder entries, removed `text-align: justify`
- **Blog data-driven (#10):** posts manifest, MDX frontmatter exports, date sorting, `<time>` elements, back-link on posts, fixed hello-word typo
- **Smooth transitions (#15):** 0.18s transitions on body/frame/bars, all motion disabled under `prefers-reduced-motion`
- **SEO/metadata (#14):** per-route metadata with OG/Twitter tags, `robots.ts`, `sitemap.ts`, noindex on `/short` and 404

Fixes #6, fixes #7, fixes #8, fixes #9, fixes #10, fixes #11, fixes #12, fixes #13, fixes #14, fixes #15

## Test plan

- [x] Verify no palette flash on first visit (clear localStorage, reload)
- [x] Check title bar shows correct path on each page
- [x] Confirm active nav link highlights with `>` prefix
- [x] Test palette/theme switching transitions are smooth
- [x] Verify skip link appears on Tab and jumps to main content
- [x] Check amber light mode contrast passes WCAG AA
- [x] Test keyboard navigation on terminal cards (`:focus-visible`)
- [x] Verify home page renders ASCII art and MOTD layout
- [x] Test resume print (Ctrl+P) renders Calibri sans-serif, hides chrome
- [x] Verify blog listing auto-generates from posts manifest
- [x] Check back-link on individual blog posts
- [x] Confirm `/robots.txt` disallows `/short/`
- [x] Confirm `/sitemap.xml` lists public routes
- [x] Test `prefers-reduced-motion` disables all animations
- [x] Verify mobile layout (<=720px) simplifies title bar