### PR TITLE
group resume roles into a timeline rail with promotion nodes

### DIFF
--- a/app/resume/ResumeRenderer.tsx
+++ b/app/resume/ResumeRenderer.tsx
@@ -30,22 +30,33 @@ export default function ResumeRenderer({ data }: { data: ResumeData }) {
           {section.entries.map((entry, i) => (
             <article key={`${entry.org}-${i}`} className={styles.entry}>
               <div className={styles.entryHeader}>
-                <div>
-                  <p className={styles.entryOrg}>{entry.org}</p>
-                  <p className={styles.entryRole}>{entry.role}</p>
-                </div>
-                <div className={styles.entryMeta}>
-                  <p className={styles.entryLocation}>{entry.location}</p>
-                  <p className={styles.entryDate}>{entry.date}</p>
-                </div>
+                <p className={styles.entryOrg}>{entry.org}</p>
+                <p className={styles.entryLocation}>{entry.location}</p>
               </div>
-              {entry.items && entry.items.length > 0 && (
-                <ul className={styles.list}>
-                  {entry.items.map((item, j) => (
-                    <li key={j}>{item}</li>
-                  ))}
-                </ul>
-              )}
+              <div
+                className={styles.roles}
+                data-multi={entry.roles.length > 1 ? "" : undefined}
+              >
+                {entry.roles.map((role, j) => (
+                  <div
+                    key={`${role.title}-${j}`}
+                    className={styles.roleBlock}
+                    data-current={j === 0 ? "" : undefined}
+                  >
+                    <div className={styles.roleHeader}>
+                      <p className={styles.roleTitle}>{role.title}</p>
+                      <p className={styles.roleDate}>{role.date}</p>
+                    </div>
+                    {role.items && role.items.length > 0 && (
+                      <ul className={styles.list}>
+                        {role.items.map((item, k) => (
+                          <li key={k}>{item}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                ))}
+              </div>
             </article>
           ))}
         </section>

--- a/app/resume/data/base.ts
+++ b/app/resume/data/base.ts
@@ -16,170 +16,218 @@ const base: ResumeData = {
       entries: [
         {
           org: "BlankOn Linux",
-          role: "Open Source Contributor (Remote)",
           location: "Indonesia",
-          date: "Dec 2025 - Present",
-          items: [
-            "Contribute to the build and packaging toolchain of an Indonesian Linux distribution, including the distributed build farm, APT repository tooling, and live ISO builder.",
-            "Help modernize project infrastructure toward GitOps on a bare-metal Proxmox cluster, with containerization and Infrastructure as Code.",
+          roles: [
+            {
+              title: "Open Source Contributor (Remote)",
+              date: "Dec 2025 - Present",
+              items: [
+                "Contribute to the build and packaging toolchain of an Indonesian Linux distribution, including the distributed build farm, APT repository tooling, and live ISO builder.",
+                "Help modernize project infrastructure toward GitOps on a bare-metal Proxmox cluster, with containerization and Infrastructure as Code.",
+              ],
+            },
           ],
         },
         {
           org: "YES2GAMES",
-          role: "Senior Programmer - Full-time (Remote)",
           location: "Singapore",
-          date: "May 2026 - Present",
-          items: [
-            "Lead online and infrastructure engineering for a cross-platform racing title, scaling its backend from a single barebone server to fully reproducible Infrastructure as Code across two data centers.",
-            "Migrated all deployments from manual SSH and ad-hoc scripts to fully automated GitOps CI/CD with GitHub Actions, rootless Podman/Quadlet containers, SOPS-encrypted secrets, and health-checked auto-rollback.",
-            "Stood up production observability with Grafana Cloud (metrics, logs, blackbox probes) and alerting, plus OpenTofu-provisioned VMs and Cloudflare DNS.",
-            "Re-architected online modules into scalable services (Go multiplayer server, backend API, IAP validation, management dashboard) and brought online support to every shipping platform.",
-          ],
-        },
-        {
-          org: "YES2GAMES",
-          role: "Junior Programmer - Full-time (Remote)",
-          location: "Singapore",
-          date: "Jul 2025 - Apr 2026",
-          items: [
-            "Ported a cross-platform racing title to web/H5 platforms (Poki, Yandex Games, Azerion, Playgama, YouTube Playables) and mobile (Google Play; App Store in progress), meeting each platform's certification and SDK requirements.",
-            "Integrated monetization, analytics, and platform SDKs across build profiles for web and mobile in Unity 6.",
-            "Set up CI/CD pipelines, automated tests, and DevSecOps practices, replacing manual builds and deployments.",
-            "Modernized client UIs to match competing titles and refactored unstructured online code into maintainable, scalable modules.",
+          roles: [
+            {
+              title: "Senior Programmer - Full-time (Remote)",
+              date: "May 2026 - Present",
+              items: [
+                "Lead online and infrastructure engineering for a cross-platform racing title, scaling its backend from a single barebone server to fully reproducible Infrastructure as Code across two data centers.",
+                "Migrated all deployments from manual SSH and ad-hoc scripts to fully automated GitOps CI/CD with GitHub Actions, rootless Podman/Quadlet containers, SOPS-encrypted secrets, and health-checked auto-rollback.",
+                "Stood up production observability with Grafana Cloud (metrics, logs, blackbox probes) and alerting, plus OpenTofu-provisioned VMs and Cloudflare DNS.",
+                "Re-architected online modules into scalable services (Go multiplayer server, backend API, IAP validation, management dashboard) and brought online support to every shipping platform.",
+              ],
+            },
+            {
+              title: "Junior Programmer - Full-time (Remote)",
+              date: "Jul 2025 - Apr 2026",
+              items: [
+                "Ported a cross-platform racing title to web/H5 platforms (Poki, Yandex Games, Azerion, Playgama, YouTube Playables) and mobile (Google Play; App Store in progress), meeting each platform's certification and SDK requirements.",
+                "Integrated monetization, analytics, and platform SDKs across build profiles for web and mobile in Unity 6.",
+                "Set up CI/CD pipelines, automated tests, and DevSecOps practices, replacing manual builds and deployments.",
+                "Modernized client UIs to match competing titles and refactored unstructured online code into maintainable, scalable modules.",
+              ],
+            },
           ],
         },
         {
           org: "Timedoor Academy",
-          role: "Programming Teacher - Part-time (On-site)",
           location: "Surabaya, Indonesia",
-          date: "May 2025 - Present",
-          items: [
-            "Delivered instruction using an adaptive learning methodology to small groups of 1-5 students in 60-to-90-minute sessions.",
-            "Instructed students on a wide range of programming topics from basic to advanced levels, including Scratch, Scratch Junior, Construct, Roblox Studio, Python, PyGame, Web Development (HTML, CSS, JS), and MIT App Inventor.",
-            "Provided detailed progress reports to parents after each learning session to ensure clear communication and tracking of student development.",
+          roles: [
+            {
+              title: "Programming Teacher - Part-time (On-site)",
+              date: "May 2025 - Present",
+              items: [
+                "Delivered instruction using an adaptive learning methodology to small groups of 1-5 students in 60-to-90-minute sessions.",
+                "Instructed students on a wide range of programming topics from basic to advanced levels, including Scratch, Scratch Junior, Construct, Roblox Studio, Python, PyGame, Web Development (HTML, CSS, JS), and MIT App Inventor.",
+                "Provided detailed progress reports to parents after each learning session to ensure clear communication and tracking of student development.",
+              ],
+            },
           ],
         },
         {
           org: "HAGE Games",
-          role: "Cheerleader - Part-time (Remote)",
           location: "Surabaya, Indonesia",
-          date: "Jan 2025 - Present",
-          items: [
-            "Mentor and advise student engineering teams within a university game-technology research group.",
-            "Provide technical direction and architecture/code review across their game and infrastructure projects.",
+          roles: [
+            {
+              title: "Cheerleader - Part-time (Remote)",
+              date: "Jan 2025 - Present",
+              items: [
+                "Mentor and advise student engineering teams within a university game-technology research group.",
+                "Provide technical direction and architecture/code review across their game and infrastructure projects.",
+              ],
+            },
           ],
         },
         {
           org: "Sepay Studio",
-          role: "Game Programmer - Part-time (Remote)",
           location: "Surabaya, Indonesia",
-          date: "Feb 2024 - Sep 2024",
-          items: [
-            "Developed and integrated features in Unreal Engine based on pre-defined designs, with a focus on backend operations.",
-            "Worked on cross-platform payment utilities using a one-gate system, ensuring smooth backend integration with various third-party services.",
-            "Designed and implemented CI/CD pipelines across Unreal Engine 4, Native Android, Native iOS, and Unity platforms, streamlining the developer workflow.",
-            "Created comprehensive documentation for implemented features, detailing technical procedures for future development and maintenance.",
+          roles: [
+            {
+              title: "Game Programmer - Part-time (Remote)",
+              date: "Feb 2024 - Sep 2024",
+              items: [
+                "Developed and integrated features in Unreal Engine based on pre-defined designs, with a focus on backend operations.",
+                "Worked on cross-platform payment utilities using a one-gate system, ensuring smooth backend integration with various third-party services.",
+                "Designed and implemented CI/CD pipelines across Unreal Engine 4, Native Android, Native iOS, and Unity platforms, streamlining the developer workflow.",
+                "Created comprehensive documentation for implemented features, detailing technical procedures for future development and maintenance.",
+              ],
+            },
           ],
         },
         {
           org: "Miracle Gates Entertainment",
-          role: "Junior Game Programmer - Full-time (On-site)",
           location: "Bali, Indonesia",
-          date: "Feb 2024 - May 2024",
-          items: [
-            "Designed and integrated backend systems used as online services within the game, such as referral codes, matchmaking, chat systems, gacha mechanics, and more.",
-            "Maintained and continually added new content to the game, ensuring seamless integration with existing content.",
-            "Iterated on previously developed features and optimized backend-related functionality to enhance performance and efficiency.",
-            "Created comprehensive documentation detailing completed, ongoing, and planned features to support team coordination.",
+          roles: [
+            {
+              title: "Junior Game Programmer - Full-time (On-site)",
+              date: "Feb 2024 - May 2024",
+              items: [
+                "Designed and integrated backend systems used as online services within the game, such as referral codes, matchmaking, chat systems, gacha mechanics, and more.",
+                "Maintained and continually added new content to the game, ensuring seamless integration with existing content.",
+                "Iterated on previously developed features and optimized backend-related functionality to enhance performance and efficiency.",
+                "Created comprehensive documentation detailing completed, ongoing, and planned features to support team coordination.",
+              ],
+            },
           ],
         },
         {
           org: "Gameloft Indonesia",
-          role: "C++ Programmer Trainee - Internship (On-site)",
           location: "Yogyakarta, Indonesia",
-          date: "Dec 2023 - Jan 2024",
-          items: [
-            "Completed tasks ranging from basic to advanced levels in C++, utilizing references and programming techniques taught during the internship.",
-            "Learned the company's workflow and organizational culture.",
-            "Studied technical aspects used by the development team and implemented acquired knowledge into assigned tasks.",
+          roles: [
+            {
+              title: "C++ Programmer Trainee - Internship (On-site)",
+              date: "Dec 2023 - Jan 2024",
+              items: [
+                "Completed tasks ranging from basic to advanced levels in C++, utilizing references and programming techniques taught during the internship.",
+                "Learned the company's workflow and organizational culture.",
+                "Studied technical aspects used by the development team and implemented acquired knowledge into assigned tasks.",
+              ],
+            },
           ],
         },
         {
           org: "Lion Core Studio",
-          role: "Junior Game Programmer - Part-time (Remote)",
           location: "Yogyakarta, Indonesia",
-          date: "Sep 2023 - Dec 2023",
-          items: [
-            "Designed and implemented an existing game design in collaboration with a senior programmer.",
-            "Collaborated with game artists to integrate technical art into the game.",
-            "Created UI related to the designed dialog system mechanics until it functioned seamlessly.",
-            "Designed algorithms and implemented enemy AI and boss characters.",
+          roles: [
+            {
+              title: "Junior Game Programmer - Part-time (Remote)",
+              date: "Sep 2023 - Dec 2023",
+              items: [
+                "Designed and implemented an existing game design in collaboration with a senior programmer.",
+                "Collaborated with game artists to integrate technical art into the game.",
+                "Created UI related to the designed dialog system mechanics until it functioned seamlessly.",
+                "Designed algorithms and implemented enemy AI and boss characters.",
+              ],
+            },
           ],
         },
         {
           org: "Electronic Engineering Polytechnic Institute of Surabaya (EEPIS)",
-          role: "Lecturer's Teaching Assistant - Part-time (On-site)",
           location: "Surabaya, Indonesia",
-          date: "Jul 2023 - Dec 2023",
-          items: [
-            "Developed a comprehensive 16-week learning curriculum by aligning weekly topics with assignments.",
-            "Delivered engaging interactions while adhering to the curriculum.",
-            "Assessed and provided constructive feedback on student assignments.",
-            "Generated weekly teaching reports to ensure alignment between activities and the curriculum.",
+          roles: [
+            {
+              title: "Lecturer's Teaching Assistant - Part-time (On-site)",
+              date: "Jul 2023 - Dec 2023",
+              items: [
+                "Developed a comprehensive 16-week learning curriculum by aligning weekly topics with assignments.",
+                "Delivered engaging interactions while adhering to the curriculum.",
+                "Assessed and provided constructive feedback on student assignments.",
+                "Generated weekly teaching reports to ensure alignment between activities and the curriculum.",
+              ],
+            },
           ],
         },
         {
           org: "Game for Education and Cultural Heritage - EEPIS Research Group",
-          role: "Game Director - Full-time (On-site)",
           location: "Surabaya, Indonesia",
-          date: "Jul 2023 - Aug 2023",
-          items: [
-            "Led and directed the development direction of a game themed around traditional food stalls.",
-            "Managed a team of 14 across Programmers, Artists, Game Designers, and Social Media Specialists.",
-            "Ensured clarity and updates in documentation from each division of the team.",
-            "Resolved and discussed issues related to the overall development.",
-          ],
-        },
-        {
-          org: "Game for Education and Cultural Heritage - EEPIS Research Group",
-          role: "Lead Game Programmer - Full-time (On-site)",
-          location: "Surabaya, Indonesia",
-          date: "Jan 2023 - Feb 2023",
-          items: [
-            "Led a technical programming team of three to design and implement an existing game design.",
-            "Coordinated and collaborated with other roles within the project.",
-            "Developed development strategies and team workflows using Technical Design Documents.",
+          roles: [
+            {
+              title: "Game Director - Full-time (On-site)",
+              date: "Jul 2023 - Aug 2023",
+              items: [
+                "Led and directed the development direction of a game themed around traditional food stalls.",
+                "Managed a team of 14 across Programmers, Artists, Game Designers, and Social Media Specialists.",
+                "Ensured clarity and updates in documentation from each division of the team.",
+                "Resolved and discussed issues related to the overall development.",
+              ],
+            },
+            {
+              title: "Lead Game Programmer - Full-time (On-site)",
+              date: "Jan 2023 - Feb 2023",
+              items: [
+                "Led a technical programming team of three to design and implement an existing game design.",
+                "Coordinated and collaborated with other roles within the project.",
+                "Developed development strategies and team workflows using Technical Design Documents.",
+              ],
+            },
           ],
         },
         {
           org: "Al-Falah Elementary School",
-          role: "Programming Teacher - Part-time (On-site)",
           location: "Surabaya, Indonesia",
-          date: "Jul 2022 - Aug 2022",
-          items: [
-            "Instructed 20 students on the basics of programming using the Scratch application.",
-            "Reviewed and evaluated the work of each student.",
-            "Conducted fun sessions to engage students and spark interest in the topics being covered.",
+          roles: [
+            {
+              title: "Programming Teacher - Part-time (On-site)",
+              date: "Jul 2022 - Aug 2022",
+              items: [
+                "Instructed 20 students on the basics of programming using the Scratch application.",
+                "Reviewed and evaluated the work of each student.",
+                "Conducted fun sessions to engage students and spark interest in the topics being covered.",
+              ],
+            },
           ],
         },
         {
           org: "Sepay Studio",
-          role: "Programmer - Part-time (Remote)",
           location: "Surabaya, Indonesia",
-          date: "Aug 2021 - Jul 2022",
-          items: [
-            "Implemented the design of a backend application for game development needs.",
-            "Executed the design of a website from the provided design into a fully functional website.",
+          roles: [
+            {
+              title: "Programmer - Part-time (Remote)",
+              date: "Aug 2021 - Jul 2022",
+              items: [
+                "Implemented the design of a backend application for game development needs.",
+                "Executed the design of a website from the provided design into a fully functional website.",
+              ],
+            },
           ],
         },
         {
           org: "Webmedia Training Center",
-          role: "Web Developer Trainee - Internship (On-site)",
           location: "Medan, Indonesia",
-          date: "Aug 2019 - Nov 2019",
-          items: [
-            "Learned and designed landing page websites using HTML, CSS, and JavaScript.",
-            "Created internship report documents for school reporting purposes and designed websites.",
+          roles: [
+            {
+              title: "Web Developer Trainee - Internship (On-site)",
+              date: "Aug 2019 - Nov 2019",
+              items: [
+                "Learned and designed landing page websites using HTML, CSS, and JavaScript.",
+                "Created internship report documents for school reporting purposes and designed websites.",
+              ],
+            },
           ],
         },
       ],
@@ -189,15 +237,23 @@ const base: ResumeData = {
       entries: [
         {
           org: "Electronic Engineering Polytechnic Institute of Surabaya (EEPIS)",
-          role: "Bachelor of Applied Science - BASc, Game Technology",
           location: "Surabaya, Indonesia",
-          date: "Aug 2021 - Aug 2025",
+          roles: [
+            {
+              title: "Bachelor of Applied Science - BASc, Game Technology",
+              date: "Aug 2021 - Aug 2025",
+            },
+          ],
         },
         {
           org: "Telkom Vocational High School",
-          role: "High School Diploma, Software Engineering",
           location: "Medan, Indonesia",
-          date: "Aug 2018 - Aug 2021",
+          roles: [
+            {
+              title: "High School Diploma, Software Engineering",
+              date: "Aug 2018 - Aug 2021",
+            },
+          ],
         },
       ],
     },
@@ -206,15 +262,17 @@ const base: ResumeData = {
       entries: [
         {
           org: "EEPIS Semi-Autonomous Body of Game Technology Students' Association",
-          role: "Head of Research and Technology Division",
           location: "Surabaya, Indonesia",
-          date: "Aug 2023 - Aug 2024",
-        },
-        {
-          org: "EEPIS Semi-Autonomous Body of Game Technology Students' Association",
-          role: "Staff of Research and Technology Division",
-          location: "Surabaya, Indonesia",
-          date: "Aug 2022 - Aug 2023",
+          roles: [
+            {
+              title: "Head of Research and Technology Division",
+              date: "Aug 2023 - Aug 2024",
+            },
+            {
+              title: "Staff of Research and Technology Division",
+              date: "Aug 2022 - Aug 2023",
+            },
+          ],
         },
       ],
     },

--- a/app/resume/resume.module.css
+++ b/app/resume/resume.module.css
@@ -13,7 +13,7 @@
 }
 
 .header {
-  margin-bottom: var(--space-4, 1rem);
+  margin-bottom: var(--space-5, 1.5rem);
 }
 
 .name {
@@ -63,7 +63,7 @@
 }
 
 .section {
-  margin-top: var(--space-4, 1rem);
+  margin-top: var(--space-5, 1.5rem);
 }
 
 .sectionTitle {
@@ -71,7 +71,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.2em;
-  margin: 0 0 var(--space-2, 0.5rem);
+  margin: 0 0 var(--space-3, 0.75rem);
   color: var(--accent, #1f2937);
   border-bottom: 2px dotted var(--accent, #1f2937);
   padding-bottom: var(--space-1, 0.25rem);
@@ -87,56 +87,110 @@
   text-align: justify;
 }
 
+/* ============================================================
+   ENTRY -- company header + role timeline rail
+   ============================================================ */
 .entry {
-  margin-top: var(--space-3, 0.75rem);
+  margin-top: var(--space-4, 1rem);
+}
+
+.entry:first-of-type {
+  margin-top: 0;
 }
 
 .entryHeader {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: var(--space-4, 1rem);
-}
-
-@media (max-width: 767px) {
-  .entryHeader {
-    grid-template-columns: 1fr;
-  }
+  align-items: baseline;
 }
 
 .entryOrg {
-  font-weight: 600;
-  margin: 0 0 var(--space-1, 0.15rem);
+  font-weight: 700;
+  color: var(--accent, #1f2937);
+  letter-spacing: 0.01em;
 }
 
-.entryRole {
-  font-style: italic;
-  margin: 0;
-}
-
-.entryMeta {
-  text-align: right;
-}
-
-@media (max-width: 767px) {
-  .entryMeta {
-    text-align: left;
-  }
+:global(.dark) .entryOrg {
+  color: var(--accent, #cbd5f5);
 }
 
 .entryLocation {
   color: var(--muted, #374151);
-  font-size: 0.88rem;
-  margin: 0 0 var(--space-1, 0.2rem);
+  font-size: 0.85rem;
+  white-space: nowrap;
 }
 
 :global(.dark) .entryLocation {
   color: var(--muted, #94a3b8);
 }
 
-.entryDate {
+/* timeline rail container */
+.roles {
+  position: relative;
+  padding-left: 1.4rem;
+  margin-top: var(--space-2, 0.5rem);
+}
+
+.roleBlock {
+  position: relative;
+}
+
+.roleBlock:not(:last-child) {
+  padding-bottom: var(--space-3, 0.75rem);
+}
+
+/* node dot in the gutter, aligned under the company name */
+.roleBlock::before {
+  content: "";
+  position: absolute;
+  box-sizing: border-box;
+  left: -1.25rem;
+  top: 0.34rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  border: 1.5px solid var(--accent, #1f2937);
+  background: var(--background, #ffffff);
+  z-index: 1;
+}
+
+/* most recent role rendered solid; earlier roles hollow */
+.roleBlock[data-current]::before {
+  background: var(--accent, #1f2937);
+}
+
+/* connector between stacked roles (only when more than one) */
+.roleBlock:not(:last-child)::after {
+  content: "";
+  position: absolute;
+  left: calc(-1rem - 0.5px);
+  top: 0.59rem;
+  width: 1px;
+  height: 100%;
+  background: var(--border-strong, #9ca3af);
+}
+
+.roleHeader {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-4, 1rem);
+  align-items: baseline;
+}
+
+.roleTitle {
   font-weight: 600;
-  font-size: 0.88rem;
-  margin: 0;
+}
+
+.roleDate {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--muted, #374151);
+  white-space: nowrap;
+}
+
+:global(.dark) .roleDate {
+  color: var(--muted, #94a3b8);
 }
 
 .page .list {
@@ -170,8 +224,16 @@
   margin: 0;
 }
 
+@media (max-width: 767px) {
+  .entryHeader,
+  .roleHeader {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+}
+
 /* ============================================================
-   PRINT -- ATS-friendly, sans-serif
+   PRINT -- ATS-friendly, sans-serif, no rail decoration
    ============================================================ */
 @media print {
   @page {
@@ -195,18 +257,14 @@
     width: 100%;
   }
 
-  .entryHeader {
-    grid-template-columns: minmax(0, 1fr) 9rem;
-  }
-
   .page {
     font-family: "Calibri", "Arial", "Helvetica Neue", sans-serif;
     background: #ffffff !important;
     color: #111827 !important;
     padding: 0;
     max-width: none;
-    font-size: 0.95rem;
-    line-height: 1.35;
+    font-size: 0.92rem;
+    line-height: 1.34;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
   }
@@ -217,7 +275,7 @@
   }
 
   .header {
-    margin-bottom: 0;
+    margin-bottom: var(--space-2, 0.5rem);
   }
 
   .name {
@@ -229,43 +287,12 @@
     margin-top: 0;
   }
 
-  .section {
-    margin-top: 0;
-  }
-
-  .sectionTitle {
-    color: #111827 !important;
-    border-bottom-color: #111827 !important;
-    break-after: avoid;
-    margin-bottom: 0;
-    padding-bottom: 0;
-  }
-
-  .entry {
-    margin-top: 0;
-    break-inside: avoid;
-    page-break-inside: avoid;
-  }
-
-  .entryOrg {
-    margin-bottom: 0;
-  }
-
-  .page .list {
-    margin-top: 0;
-  }
-
-  .page .list li {
-    margin-bottom: 0;
-  }
-
-  .contact {
+  .contact,
+  .contact a {
     color: #1f2937 !important;
-    margin-top: 0;
   }
 
   .contact a {
-    color: #1f2937 !important;
     text-decoration: none !important;
   }
 
@@ -273,12 +300,61 @@
     color: #6b7280 !important;
   }
 
-  .entryDate {
+  .section {
+    margin-top: var(--space-3, 0.75rem);
+  }
+
+  .sectionTitle {
+    color: #111827 !important;
+    border-bottom: 1px solid #111827 !important;
+    break-after: avoid;
+    margin-bottom: var(--space-1, 0.25rem);
+    padding-bottom: 0.1rem;
+  }
+
+  .summary {
+    margin-bottom: var(--space-1, 0.25rem);
+  }
+
+  .entry {
+    margin-top: var(--space-2, 0.5rem);
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .entryOrg {
     color: #111827 !important;
   }
 
   .entryLocation {
     color: #374151 !important;
+  }
+
+  /* strip the rail; keep a quiet indent so grouped roles still read together */
+  .roles {
+    margin-top: 0;
+    padding-left: 0.75rem;
+  }
+
+  .roleBlock::before,
+  .roleBlock:not(:last-child)::after {
+    display: none !important;
+  }
+
+  .roleBlock:not(:last-child) {
+    padding-bottom: var(--space-1, 0.25rem);
+  }
+
+  .roleDate {
+    color: #111827 !important;
+  }
+
+  .page .list {
+    margin-top: var(--space-1, 0.2rem);
+  }
+
+  .page .list li {
+    margin-bottom: 0;
   }
 
   .page .list li::before {

--- a/app/resume/types.ts
+++ b/app/resume/types.ts
@@ -3,12 +3,16 @@ export interface ContactItem {
   href: string;
 }
 
-export interface ResumeEntry {
-  org: string;
-  role: string;
-  location: string;
+export interface ResumeRole {
+  title: string;
   date: string;
   items?: string[];
+}
+
+export interface ResumeEntry {
+  org: string;
+  location: string;
+  roles: ResumeRole[];
 }
 
 export interface ResumeSection {


### PR DESCRIPTION
## Summary
- Group same-company roles under one company header with a CSS-drawn timeline rail (filled node = current role, hollow = past), LinkedIn-style
- Connectors drawn as pseudo-elements (not DOM text) so ATS parsers and copy-paste stay clean
- Print mode strips the rail and stays ATS-clean sans-serif

## Test plan
- Verified screen views (dark/light/mobile) and print PDF via playwright-cli
- `tsc --noEmit` passes