### PR TITLE
Revamp resume layout with grid-cell IDE file-tree

### DIFF
--- a/app/resume/ResumeRenderer.tsx
+++ b/app/resume/ResumeRenderer.tsx
@@ -5,6 +5,7 @@ export default function ResumeRenderer({ data }: { data: ResumeData }) {
   return (
     <section className={styles.page}>
       <section className={styles.header}>
+        <span className={styles.prompt} aria-hidden="true" />
         <h1 className={styles.name}>{data.name}</h1>
         <p className={styles.role}>{data.role}</p>
         <p className={styles.contact}>

--- a/app/resume/resume.module.css
+++ b/app/resume/resume.module.css
@@ -16,6 +16,30 @@
   margin-bottom: var(--space-5, 1.5rem);
 }
 
+/* shell-session flourish: `> whoami` drawn entirely as pseudo content so it
+   is never copied or extracted. screen only -- hidden in print. */
+.prompt {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--muted, #6b7280);
+  margin: 0 0 var(--space-1, 0.25rem);
+  letter-spacing: 0.02em;
+}
+
+.prompt::before {
+  content: ">";
+  margin-right: 0.6ch;
+  color: var(--accent, #245a9e);
+}
+
+.prompt::after {
+  content: "whoami";
+}
+
+:global(.dark) .prompt::after {
+  color: var(--muted, #94a3b8);
+}
+
 .name {
   font-size: 2.1rem;
   letter-spacing: 0.08em;
@@ -98,8 +122,15 @@
   letter-spacing: 0.2em;
   margin: 0 0 var(--space-3, 0.75rem);
   color: var(--accent, #1f2937);
-  border-bottom: 1px dotted var(--border-strong, color-mix(in srgb, var(--accent) 45%, transparent));
+  border-bottom: 1px solid var(--border-strong, color-mix(in srgb, var(--accent) 45%, transparent));
   padding-bottom: var(--space-1, 0.25rem);
+}
+
+/* command-line prompt prefix -- decoration only, ATS reads "Experience" etc. */
+.sectionTitle::before {
+  content: "$ ";
+  color: var(--accent, #245a9e);
+  font-weight: 400;
 }
 
 :global(.dark) .sectionTitle {
@@ -164,58 +195,94 @@
 }
 
 /* ------------------------------------------------------------
-   timeline rail -- one continuous line spanning a company's
-   roles, a node per role. drawn purely with pseudo-elements
-   so copy-paste / ATS parsing stay clean.
-   geometry: node center sits at the role-title line center
-   (font 0.95rem * line-height 1.45 => ~0.69rem from block top).
+   IDE file-tree for multi-role companies. markers are drawn 1px
+   lines (pseudo-elements) positioned by GRID-CELL alignment --
+   never by guessed rem offsets -- so a marker physically cannot
+   enter the text column, and the tick centers on the title line
+   regardless of font metrics or wrapping.
    ------------------------------------------------------------ */
 .roles {
-  --rail-x: 0.28rem;
-  --node: 0.5rem;
-  --node-center-y: 0.69rem;
-  position: relative;
-  padding-left: 1.5rem;
+  --tree-gutter: 1.5rem; /* reserved marker column; constant width */
+  --tick-x: 0.45rem; /* x of the vertical line within the gutter */
+  --tick-gap: 0.32rem; /* gap between tick end and the title */
+  --tree-line: color-mix(in srgb, var(--accent) 55%, transparent);
 }
 
+/* every role -- single- or multi-role -- reserves the gutter so all
+   titles share one clean left edge. content always lives in column 2. */
 .roleBlock {
   position: relative;
+  display: grid;
+  grid-template-columns: var(--tree-gutter) minmax(0, 1fr);
+}
+
+.roleBlock > * {
+  grid-column: 2;
 }
 
 .roleBlock:not(:last-child) {
   padding-bottom: var(--space-4, 1rem);
 }
 
-/* node dot, vertically centered on the role title */
-.roleBlock::before {
+/* horizontal tick: a 1px line from the vertical connector to the
+   content, grid-centered on the title row -- no rem offset, robust
+   to title wrapping. */
+.roles[data-multi] .roleBlock::after {
   content: "";
-  position: absolute;
-  box-sizing: border-box;
-  left: calc(var(--rail-x) - var(--node) / 2);
-  top: calc(var(--node-center-y) - var(--node) / 2);
-  width: var(--node);
-  height: var(--node);
-  border-radius: 50%;
-  border: 2px solid var(--accent, #1f2937);
-  background: var(--background, #ffffff);
-  z-index: 1;
+  grid-column: 1;
+  grid-row: 1;
+  align-self: center;
+  justify-self: start;
+  margin-left: var(--tick-x);
+  width: calc(var(--tree-gutter) - var(--tick-x) - var(--tick-gap));
+  height: 1px;
+  background: var(--tree-line);
 }
 
-/* most recent role solid + glow; earlier roles hollow */
-.roleBlock[data-current]::before {
-  background: var(--accent, #1f2937);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
-}
-
-/* connector from this node down to the next node */
-.roles[data-multi] .roleBlock:not(:last-child)::after {
+/* vertical connector for non-last roles spans the full block box
+   (incl. padding) so it joins seamlessly into the next role's line. */
+.roles[data-multi] .roleBlock:not(:last-child)::before {
   content: "";
   position: absolute;
-  left: calc(var(--rail-x) - 0.5px);
-  top: var(--node-center-y);
+  left: var(--tick-x);
+  top: 0;
+  bottom: 0;
   width: 1px;
-  height: 100%;
-  background: color-mix(in srgb, var(--accent) 55%, transparent);
+  background: var(--tree-line);
+}
+
+/* last role: line runs from block top to the tick center only (└),
+   not through the bullets. the gradient's 50% stop equals the
+   single-line title's center, so it meets the grid-centered tick
+   without any guessed offset. */
+.roles[data-multi] .roleBlock:last-child::before {
+  content: "";
+  grid-column: 1;
+  grid-row: 1;
+  align-self: stretch;
+  justify-self: start;
+  margin-left: var(--tick-x);
+  width: 1px;
+  background: linear-gradient(to bottom, var(--tree-line) 0 50%, transparent 50%);
+}
+
+/* current role title carries the accent; past roles stay foreground.
+   no filled/hollow dot -- that dot was the original overlap bug. */
+.roleBlock[data-current] .roleTitle {
+  color: var(--accent, #245a9e);
+}
+
+:global(.dark) .roleBlock[data-current] .roleTitle {
+  color: var(--accent, #6aa8ff);
+}
+
+/* current role's tick reads brighter than the connector line. */
+.roles[data-multi] .roleBlock[data-current]::after {
+  background: var(--accent, #245a9e);
+}
+
+:global(.dark) .roles[data-multi] .roleBlock[data-current]::after {
+  background: var(--accent, #6aa8ff);
 }
 
 .roleHeader {
@@ -309,14 +376,32 @@
 }
 
 @media (max-width: 767px) {
-  .entryHeader,
-  .roleHeader {
+  .entryHeader {
     grid-template-columns: 1fr;
     gap: 0;
   }
 
+  /* flatten roleHeader so its title and date become rows of .roleBlock.
+     the tick lives in grid-row 1, which now maps to the TITLE alone --
+     so it keeps centering on the title, not on the stacked title+date. */
+  .roleHeader {
+    display: contents;
+  }
+
+  .roleTitle {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
   .roleDate {
+    grid-column: 2;
+    grid-row: 2;
     margin-top: 0.1rem;
+  }
+
+  /* tree gutter narrows but stays; lines still align via the grid. */
+  .roles {
+    --tree-gutter: 1.25rem;
   }
 }
 
@@ -364,6 +449,12 @@
 
   .header {
     margin-bottom: var(--space-2, 0.5rem);
+  }
+
+  /* drop all terminal flourishes for a clean ATS document */
+  .prompt,
+  .sectionTitle::before {
+    display: none !important;
   }
 
   .name {
@@ -452,13 +543,14 @@
     color: #1f2937 !important;
   }
 
-  /* strip the rail; keep a quiet indent so grouped roles still read together */
+  /* strip all tree lines; collapse the gutter to a quiet indent so
+     grouped roles still read together. */
   .roles {
-    padding-left: 0.85rem;
+    --tree-gutter: 0.7rem;
   }
 
   .roleBlock::before,
-  .roleBlock:not(:last-child)::after {
+  .roleBlock::after {
     display: none !important;
   }
 

--- a/docs/superpowers/specs/2026-06-07-resume-ui-revamp-design.md
+++ b/docs/superpowers/specs/2026-06-07-resume-ui-revamp-design.md
@@ -1,0 +1,221 @@
+# Resume page UI revamp — design spec
+
+Date: 2026-06-07
+Route: `/resume` — `app/resume/`
+Files in scope: `ResumeRenderer.tsx`, `resume.module.css`, `data/base.ts` (layout-driven only), `types.ts`
+Reference only (do not restyle the whole site): `app/globals.css`
+
+## Goal
+
+Make every surface of the resume — dark, light, and ATS print — genuinely clean.
+Kill the timeline-rail overlap bug structurally, not with another hardcoded offset.
+Sharpen the terminal/IDE register the site already owns: an IDE file-tree for
+multi-role companies, a prompt-style header, command-line section dividers — all
+decoration drawn as pseudo-elements so copy/paste and ATS extraction stay text-clean.
+
+This is a layout + craft revamp. Resume data content/wording is NOT changed beyond
+what layout needs.
+
+## Locked aesthetic (preserve, do not introduce a new lane)
+
+- Fira Code monospace (`font-family: inherit` from globals). No new fonts.
+- `data-layout="terminal"`, `--radius: 0` (square corners), `data-palette` accent
+  via `--accent`. Scanline + noise overlays stay (they live on `body`, untouched).
+- Left-aligned text. No `text-align: justify` (monospace stretches word gaps).
+- Name keeps its accent glow + blinking block cursor (screen only).
+
+## Root cause of the current bug (what we are fixing)
+
+`.roleBlock::before` (the node dot) is absolutely positioned at `left ≈ 0.03rem`
+relative to `.roleBlock`. But `.roleBlock`'s left edge already sits at the content
+start, because the `padding-left: 1.5rem` gutter lives on the *parent* `.roles`, not
+on `.roleBlock`. So the dot renders ~0.03rem INTO the text column → "●enior Programmer".
+
+The vertical position also relies on a hardcoded `--node-center-y: 0.69rem` guessed
+from font-size × line-height. Any wrap or metric drift moves the dot off the line.
+
+**Fix class:** position markers by grid-cell alignment, never by guessed rem offsets.
+A marker that lives in its own gutter grid column physically cannot enter the text
+column, and `align-items: center` on the title row centers the tick on the title line
+regardless of font metrics or wrapping.
+
+## Layout
+
+### Structure (DOM, in `ResumeRenderer.tsx`)
+
+```
+section.page
+  header.header
+    span.prompt            > whoami        (pseudo decoration; screen only)
+    h1.name                ATQA MUNZIR▮    (glow + cursor)
+    p.role                 Coder
+    p.contact              email | linkedin | github
+  section.section (Summary)
+    h2.sectionTitle        Summary
+    p.summary
+  section.section (Experience | Education | Organization)
+    h2.sectionTitle
+    article.entry
+      div.entryHeader      > ORG            Location
+      div.roles[data-multi]
+        div.roleBlock[data-current]
+          div.roleHeader   Role title       date
+          ul.list          - bullet
+```
+
+The DOM stays essentially as today. New: a `.prompt` span in the header for the
+`> whoami` flourish (its text is a pseudo-element `content`, so it is never copied
+or extracted). `data-multi` on `.roles` already flags multi-role companies; `data-current`
+on the first `.roleBlock` flags the current role.
+
+### Header — prompt-style (bolder)
+
+A shell-session read, complementing (not duplicating) the existing `/resume` hero above:
+
+```
+> whoami            <- small, muted, accent ">"; pseudo decoration, screen only
+ATQA MUNZIR▮        <- accent + glow + blinking block cursor (locked)
+Coder
+atqamz@gmail.com | linkedin.com/in/atqamunzir | github.com/atqamz
+```
+
+- `> whoami` is a `::before`/`content` flourish on a `.prompt` element — stripped in
+  print, absent from copy/ATS text. It reads as "ran whoami, got the identity below."
+- Name, role, contact otherwise unchanged from today (glow, cursor, accent links,
+  accent-tinted ` | ` separators at 0.55 opacity).
+
+### Section dividers — command-line (bolder)
+
+Three distinct terminal glyph levels give clear hierarchy:
+
+- **Section** title: prompt prefix `$ ` (pseudo `::before`), uppercase + letter-spacing
+  as today, followed by a full-width 1px rule. The `$ ` and the rule are decoration;
+  the heading text from data ("Experience") stays intact for ATS.
+- **Company**: `> ORG` — the existing `>` prompt marker (pseudo `::before`), accent-muted.
+- **Role**: IDE tree branch `├─ / └─` (drawn lines, see below).
+
+Divider stays quieter than the name in the visual hierarchy: rule uses `--border-strong`,
+title uses `--accent` but no glow. The name keeps the only glow on the page.
+
+### Experience — IDE file-tree for multi-role companies
+
+Chosen pattern: tree markers. Multi-role companies render their roles as a file tree;
+single-role companies get no tree marker (just the role under the company prompt).
+
+```
+> YES2GAMES                          Singapore
+  ├─ Senior Programmer               May 2026 - Present
+  │    - Lead online and infra scaling...
+  │    - Migrated to GitOps CI/CD...
+  └─ Junior Programmer               Jul 2025 - Apr 2026
+       - Ported racing title to web/H5...
+
+> BlankOn Linux                      Indonesia
+   Open Source Contributor           Dec 2025 - Present   <- single role, no tree
+     - Contribute to build toolchain...
+```
+
+**Geometry (bulletproof):**
+
+- `.roleBlock` is a grid: `grid-template-columns: var(--tree-gutter) minmax(0, 1fr)`.
+  `--tree-gutter` ≈ `1.6rem`. The tree column is ALWAYS reserved (constant width) so
+  every role title shares one clean left edge — single-role and multi-role alike.
+- The tree marks are **drawn 1px lines** (pseudo-elements), not text glyphs:
+  - vertical connector `│`: a 1px-wide pseudo in the gutter column, spanning the
+    `.roleBlock` height; for the last role it stops at the tick (a `└`, not a through `│`).
+  - horizontal tick `─`: a short 1px-high pseudo from the vertical line to the content,
+    vertically centered on the `.roleHeader` row via grid `align-items: center` —
+    no hardcoded rem offset, robust to title wrapping.
+- Tree only draws when `.roles[data-multi]`. Single-role companies leave the gutter empty.
+- Drawn lines (vs literal box-drawing characters) connect perfectly across any number
+  of bullet lines and never depend on glyph metrics. Visually identical to `├─└│` at 1px.
+
+**Current vs past role:** the current role (`[data-current]`) gets its title in `--accent`;
+past roles in `--foreground`. No filled/hollow dot (that dot was the bug source). The
+distinction is carried by title color weight, which also survives as bold-ish emphasis
+in print if desired (kept subtle).
+
+**Company header:** `> ORG` left, `Location` right (existing 2-col grid, `auto` date col).
+`break-after: avoid` keeps the header attached to its first role.
+
+### Education
+
+Same renderer. Both entries are single-role with no bullets:
+
+```
+> EEPIS (full name)                  Surabaya, Indonesia
+   Bachelor of Applied Science - BASc, Game Technology   Aug 2021 - Aug 2025
+```
+
+No tree (single role). Degree title + date on the role row. Reads as a compact two-line
+block per school.
+
+### Organization
+
+`EEPIS ... Students' Association` has two roles, no bullets — so it DOES get a tree, with
+the connector spanning the two title rows even though there are no bullets between them
+(the drawn vertical line spans `.roleBlock` height, so it works with zero bullets):
+
+```
+> EEPIS ... Students' Association    Surabaya, Indonesia
+  ├─ Head of Research and Technology Division     Aug 2023 - Aug 2024
+  └─ Staff of Research and Technology Division     Aug 2022 - Aug 2023
+```
+
+## Dark / light
+
+- All colors via tokens: `--accent`, `--foreground`, `--muted`, `--border-strong`,
+  `--background`. No literal colors in screen styles.
+- Tree lines: `color-mix(in srgb, var(--accent) ~55%, transparent)`, current node/tick
+  brighter. Verify visibility in BOTH light (e.g. blue `#245a9e`, amber `#8a6200`) and
+  dark (`#6aa8ff`, `#eec35e`) palettes — light palettes are lower-contrast lines, must
+  still read.
+- Name glow `text-shadow ... var(--accent) 35%`; contact separators accent at 0.55.
+
+## ATS print (Ctrl+P must be excellent)
+
+Strip ALL decoration; produce a plain, selectable, correctly-ordered sans-serif doc.
+
+- `font-family: "Calibri", "Arial", "Helvetica Neue", sans-serif`, black `#111827`
+  on white `#ffffff`, `print-color-adjust: exact`.
+- `display: none !important` for: `.prompt` (`> whoami`), name glow (`text-shadow: none`),
+  name cursor (`.name::after`), section prompt (`$ `), company prompt (`.entryOrg::before` `>`),
+  all tree lines (`.roleBlock` vertical + tick pseudo-elements), scanline/noise (site
+  chrome already hidden via existing `:global(header/footer/.terminal-hero/...) { display:none }`).
+- Reading order (top to bottom): NAME, Coder, contacts, then each section: TITLE, then
+  per company: ORG, Location, role title, date, bullets. Tree gutter collapses to a small
+  indent; bullets stay hyphen-prefixed (pseudo `-`, ATS-safe).
+- **Page packing (locked technique):** `break-inside: avoid` on `.roleBlock` AND `li`
+  (keep each role + its bullets intact); `.entry` flows freely; `break-after: avoid` on
+  `.entryHeader` (no orphaned company header). No split bullet lists, no big bottom gaps.
+- **pdftotext verification:** extracted text must contain NONE of these glyphs:
+  `> $ ├ └ │ ─ ● ○ ▮` and no literal `whoami`. Bullet hyphens are pseudo-elements so they
+  do not appear in extracted text either. Confirm reading order and content are intact.
+
+## Mobile (≤767px)
+
+- `.entryHeader` and `.roleHeader` collapse to single column (date drops below title) —
+  existing behavior, preserved. Tree gutter narrows but stays; lines still align via grid.
+
+## Content constraints (must not violate)
+
+- NEVER name the project. Say "cross-platform racing title" (data already complies).
+- HAGE Games entry stays mentor/advisor only — no implied hands-on project work (complies).
+- Do not change resume data content/wording beyond layout needs. Data lives in `base.ts`.
+
+## Verification plan (playwright-cli, every iteration)
+
+1. `npm run dev`, load `/resume`.
+2. Screenshot dark + light (toggle theme) at desktop width; spot-check a narrow width.
+   Read the screenshots critically — confirm no marker touches any title, clean left edge,
+   hierarchy reads (name wins), dividers and tree look intentional.
+3. `emulateMedia({ media: 'print' })` + `page.pdf()` → save PDF.
+4. `pdftotext` the PDF → assert none of the prohibited glyphs / `whoami` appear; confirm
+   reading order and that all content is present and selectable.
+5. Iterate until each surface is genuinely clean before claiming done.
+
+## Out of scope
+
+- No restyle of the rest of the site (globals, header/hero chrome beyond print-hiding).
+- No new dependencies, no new fonts, no new aesthetic lane.
+- No data rewording.


### PR DESCRIPTION
## Summary
- Replace the timeline rail/dot with a grid-cell IDE file-tree: markers live in a reserved gutter column and center on the title line via grid alignment, structurally killing the node-dot overlap bug (no more guessed rem offsets).
- Sharpen the terminal register: screen-only `> whoami` prompt, `$ ` section prefixes, current-role accent. All decoration is pseudo-element content, so copy/paste and ATS print stay text-clean.
- Mobile: flatten the role header with `display:contents` so the tick keeps centering on the title, not the stacked date.

## Test plan
- Verified dark + light at desktop and ≤767px via playwright: one clean title left edge, tick centered with a clear gap, no marker touches text; single-role, multi-role, and zero-bullet (org) entries all render.
- Print PDF (`emulateMedia('print')` + `page.pdf`) -> `pdftotext`: 3 pages, sans-serif, correct reading order, content intact, and none of `> $ tree-glyphs cursor` or `whoami` in extracted text.